### PR TITLE
feat(devops): Add new DevOps playbook files

### DIFF
--- a/playbooks/perforce/commit_playbook.yml
+++ b/playbooks/perforce/commit_playbook.yml
@@ -1,0 +1,39 @@
+---
+- name: Run mkrep.sh on a host and do the live backup
+  hosts: localhost
+  vars_prompt:
+    - name: replica_hostname
+      prompt: "Enter the replica hostname"
+      private: no
+
+  tasks:
+    - name: Execute mkrep.sh script with parameters
+      become: yes
+      ansible.builtin.command:
+        cmd: "/hxdepots/p4/common/bin/mkrep.sh -os -i 1 -t fr -s awseuwest1 -r {{ replica_hostname }}"
+
+    - name: Change to perforce user and source vars, then run live_checkpoint.sh
+      become: yes
+      become_user: perforce
+      ansible.builtin.shell: |
+        source /p4/common/bin/p4_vars 1 && /p4/common/bin/live_checkpoint.sh 1
+
+    - name: Add export to /etc/exports
+      become: yes
+      ansible.builtin.lineinfile:
+        path: /etc/exports
+        line: "/hxdepots/p4/1/checkpoints *(ro,no_all_squash)"
+        state: present
+        create: yes
+    
+    - name: Restart and enable NFS server
+      become: yes
+      ansible.builtin.systemd:
+        name: nfs-server
+        state: restarted
+        enabled: yes
+
+
+
+        
+        

--- a/playbooks/perforce/replica_playbook.yml
+++ b/playbooks/perforce/replica_playbook.yml
@@ -1,0 +1,74 @@
+---
+- name: Set up NFS client and handle checkpoints
+  hosts: localhost
+  vars_prompt:
+    - name: ec2_private_dns
+      prompt: "Enter the server private DNS name"
+      private: no
+    - name: checkpoint_file_name
+      prompt: "Enter the checkpoint file name"
+      private: no
+
+  tasks:
+    - name: Mount NFS share to /mnt
+      become: yes
+      ansible.builtin.mount:
+        path: /mnt
+        src: '{{ ec2_private_dns }}:/hxdepots/p4/1/checkpoints'
+        fstype: nfs
+        opts: ro
+        state: mounted
+
+    - name: Find the newest file in /mnt
+      become: yes
+      become_user: perforce
+      ansible.builtin.shell: |
+        cd /mnt
+        newest_file=$(ls -Art | tail -n 1)
+        if [ -z "$newest_file" ]; then
+          echo "No files found in /mnt."
+          exit 1
+        else
+          echo "The newest file in /mnt is: $newest_file"
+          # Proceed with copying the file to /hxdepots/p4/1/checkpoints
+          cp -a "/mnt/$newest_file" /hxdepots/p4/1/checkpoints/
+        fi
+      register: find_newest_file
+
+    - name: Copy checkpoint files from /mnt to /hxdepots/p4/1/checkpoints
+      become: yes
+      ansible.builtin.command:
+        cmd: "cp -a /mnt/* /hxdepots/p4/1/checkpoints/"
+      become_user: perforce
+
+    - name: Create server.id file
+      become: yes
+      ansible.builtin.shell:
+        cmd: "echo p4d_fr_awseuwest1 > /p4/1/root/server.id"
+      become_user: perforce
+
+    - name: Trust the remote server
+      become: yes
+      ansible.builtin.shell:
+        cmd: "p4 ssl:{{ ec2_private_dns }}:1666 trust"
+      become_user: perforce
+
+    - name: Login to remote server with admin account
+      become: yes
+      ansible.builtin.shell:
+        cmd: "p4 -p ssl:{{ ec2_private_dns }}:1666 login -a < /p4/common/config/.p4passwd.p4_1.admin"
+      become_user: perforce
+
+    - name: Login to remote server with service account
+      become: yes
+      ansible.builtin.shell:
+        cmd: "p4 -p ssl:{{ ec2_private_dns }}:1666 login svc_p4d_fr_awseuwest1"
+      become_user: perforce
+
+    - name: Load the checkpoint using the newest file from /mnt
+      become: yes
+      ansible.builtin.shell: |
+        newest_file=$(ls -Art /mnt | tail -n 1)
+        nohup load_checkpoint.sh "/p4/1/checkpoints/$newest_file" -i 1 -y < /dev/null > /dev/null 2>&1 &
+      become_user: perforce
+      when: find_newest_file.stdout is defined and find_newest_file.stdout != ''


### PR DESCRIPTION
This commit adds two new DevOps playbook files:
- commit_playbook.yml
- replica_playbook.yml

The commit_playbook.yml file contains commit server post configuration The replica_playbook.yml file contains the tasks and configurations to set up replica server.

**Issue number:**

## Summary

### Changes

> These two playbooks configure the commit server and the new replica server to form replication link on Helix Core.

### User experience

> Users will be able to setup replication link between replica and commit server (full replica "unfiltered").

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.