### PR TITLE
fix: fix issue where SSH public key was not baked into the Windows Jenkins build agent AMI

### DIFF
--- a/assets/packer/build-agents/windows/windows.pkr.hcl
+++ b/assets/packer/build-agents/windows/windows.pkr.hcl
@@ -146,7 +146,7 @@ build {
     elevated_password = build.Password
     inline = [
       "$authorizedKey = '${var.public_key}'",
-      "powershell Add-Content -Force -Path $env:ProgramData/ssh/administrators_authorized_keys -Value '$authorizedKey';icacls.exe \"\"$env:ProgramData/ssh/administrators_authorized_keys\"\" /inheritance:r /grant \"\"Administrators:F\"\" /grant \"\"SYSTEM:F\"\"",
+      "Add-Content -Force -Path $env:ProgramData/ssh/administrators_authorized_keys -Value $authorizedKey;icacls.exe \"\"$env:ProgramData/ssh/administrators_authorized_keys\"\" /inheritance:r /grant \"\"Administrators:F\"\" /grant \"\"SYSTEM:F\"\"",
       "Get-Disk | where partitionstyle -eq \"raw\" | Initialize-Disk -PartitionStyle GPT -PassThru | New-Partition -AssignDriveLetter -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel \"Data Drive\" -Confirm:$false"
     ]
   }


### PR DESCRIPTION
**Issue number:** #148 

## Summary

### Changes

Fixes an issue where the SSH public key was not getting baked into the Windows Jenkins build agent AMI.

### User experience

No changes to user experience

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

(no changes to documentation are needed)

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.