### PR TITLE
fix: wait for cloud-init to complete prior to installing packages during Perforce Helix Core AMI creation

### DIFF
--- a/assets/packer/perforce/helix-core/perforce.pkr.hcl
+++ b/assets/packer/perforce/helix-core/perforce.pkr.hcl
@@ -70,6 +70,7 @@ build {
 
     provisioner "shell" {
       inline = [
+        "cloud-init status --wait",
         "sudo dnf install -y git sendmail nfs-utils s-nail unzip cronie"
       ]
     }


### PR DESCRIPTION
**Issue number:** #192 

## Summary

### Changes

Prior to installing packages, the install script now waits for cloud-init to complete

### User experience

No changes to user experience

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

(no documentation changes necessary)

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.