### PR TITLE
fix: dependabot grouping terraform providers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,19 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    groups:
+      aws-provider:
+        applies-to: version-updates
+        patterns:
+          -hashicorp/aws
+      awscc-provider:
+        applies-to: version-updates
+        patterns:
+          -hashicorp/awscc
+      random-provider:
+        applies-to: version-updates
+        patterns:
+          -hashicorp/random
     schedule:
       interval: "daily"
   - package-ecosystem: "docker"


### PR DESCRIPTION
**Issue number:**

#227 

## Summary

Adds dependabot grouping for terraform provider version bumps.

### Changes

> Please provide a summary of what's being changed

Add group definitions for current AWS and Random TF providers.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.