### PR TITLE
Gabeaws/jenkins/complete example

### DIFF
--- a/modules/jenkins/examples/complete/dns.tf
+++ b/modules/jenkins/examples/complete/dns.tf
@@ -1,0 +1,67 @@
+##########################################
+# Route53 Hosted Zone for FQDN
+##########################################
+data "aws_route53_zone" "root" {
+  name         = local.fully_qualified_domain_name
+  private_zone = false
+}
+
+# resource "aws_route53_zone" "root" {
+#   name = local.fully_qualified_domain_name
+#   #checkov:skip=CKV2_AWS_38: DNSSEC signing disabled by design
+#   #checkov:skip=CKV2_AWS_39: Query logging disabled by design
+# }
+
+resource "aws_route53_record" "jenkins" {
+  zone_id = data.aws_route53_zone.root.id
+  name    = "jenkins.${data.aws_route53_zone.root.name}"
+  type    = "A"
+  alias {
+    name                   = module.jenkins.jenkins_alb_dns_name
+    zone_id                = module.jenkins.jenkins_alb_zone_id
+    evaluate_target_health = true
+  }
+}
+
+##########################################
+# Jenkins Certificate Management
+##########################################
+
+resource "aws_acm_certificate" "jenkins" {
+  domain_name       = "jenkins.${data.aws_route53_zone.root.name}"
+  validation_method = "DNS"
+
+  tags = {
+    Environment = "dev"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "jenkins_cert" {
+  for_each = {
+    for dvo in aws_acm_certificate.jenkins.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.root.id
+}
+
+# tflint-ignore: terraform_required_providers
+resource "aws_acm_certificate_validation" "jenkins" {
+  timeouts {
+    create = "15m"
+  }
+  certificate_arn         = aws_acm_certificate.jenkins.arn
+  validation_record_fqdns = [for record in aws_route53_record.jenkins_cert : record.fqdn]
+}

--- a/modules/jenkins/examples/complete/dns.tf
+++ b/modules/jenkins/examples/complete/dns.tf
@@ -2,15 +2,9 @@
 # Route53 Hosted Zone for FQDN
 ##########################################
 data "aws_route53_zone" "root" {
-  name         = local.fully_qualified_domain_name
+  name         = var.fully_qualified_domain_name
   private_zone = false
 }
-
-# resource "aws_route53_zone" "root" {
-#   name = local.fully_qualified_domain_name
-#   #checkov:skip=CKV2_AWS_38: DNSSEC signing disabled by design
-#   #checkov:skip=CKV2_AWS_39: Query logging disabled by design
-# }
 
 resource "aws_route53_record" "jenkins" {
   zone_id = data.aws_route53_zone.root.id
@@ -57,7 +51,6 @@ resource "aws_route53_record" "jenkins_cert" {
   zone_id         = data.aws_route53_zone.root.id
 }
 
-# tflint-ignore: terraform_required_providers
 resource "aws_acm_certificate_validation" "jenkins" {
   timeouts {
     create = "15m"

--- a/modules/jenkins/examples/complete/local.tf
+++ b/modules/jenkins/examples/complete/local.tf
@@ -1,0 +1,43 @@
+data "aws_availability_zones" "available" {}
+
+
+locals {
+  # Simple Build Pipeline Configuration
+  fully_qualified_domain_name = "example.com" # update this to the root domain name you own
+
+  # IPV4 CIDR blocks that need Jenkins access. For example:
+  # "<my personal ip>/32"
+
+  # tflint-ignore: terraform_unused_declarations
+  allowlist = []
+
+  # Jenkins and Build Farm Configurations
+  jenkins_agent_secret_arns = []
+
+  build_farm_compute = {
+    example_builders : {
+      ami           = "ami-066784287e358dad1" // Amazon Linux 2023 (64-bit x86)
+      instance_type = "t3.medium"
+    }
+  }
+
+  build_farm_fsx_openzfs_storage = {
+    cache : {
+      storage_type        = "SSD"
+      throughput_capacity = 160
+      storage_capacity    = 256
+      deployment_type     = "MULTI_AZ_1"
+      route_table_ids     = [aws_route_table.private_rt.id]
+    }
+  }
+
+  # VPC Configuration
+  vpc_cidr_block       = "10.0.0.0/16"
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.3.0/24", "10.0.4.0/24"]
+
+  tags = {
+    environment = "cgd"
+  }
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+}

--- a/modules/jenkins/examples/complete/local.tf
+++ b/modules/jenkins/examples/complete/local.tf
@@ -2,17 +2,6 @@ data "aws_availability_zones" "available" {}
 
 
 locals {
-  # Simple Build Pipeline Configuration
-  fully_qualified_domain_name = "example.com" # update this to the root domain name you own
-
-  # IPV4 CIDR blocks that need Jenkins access. For example:
-  # "<my personal ip>/32"
-
-  # tflint-ignore: terraform_unused_declarations
-  allowlist = []
-
-  # Jenkins and Build Farm Configurations
-  jenkins_agent_secret_arns = []
 
   build_farm_compute = {
     example_builders : {

--- a/modules/jenkins/examples/complete/main.tf
+++ b/modules/jenkins/examples/complete/main.tf
@@ -1,0 +1,64 @@
+# tflint-ignore: terraform_required_version
+
+##########################################
+# Shared ECS Cluster for Services
+##########################################
+
+resource "aws_ecs_cluster" "build_pipeline_cluster" {
+  name = "build-pipeline-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+}
+
+resource "aws_ecs_cluster_capacity_providers" "providers" {
+  cluster_name = aws_ecs_cluster.build_pipeline_cluster.name
+
+  capacity_providers = ["FARGATE"]
+
+  default_capacity_provider_strategy {
+    base              = 1
+    weight            = 100
+    capacity_provider = "FARGATE"
+  }
+}
+
+##########################################
+# Jenkins
+##########################################
+
+module "jenkins" {
+  source = "../.."
+
+  cluster_name                   = aws_ecs_cluster.build_pipeline_cluster.name
+  vpc_id                         = aws_vpc.build_pipeline_vpc.id
+  jenkins_alb_subnets            = aws_subnet.public_subnets[*].id
+  jenkins_service_subnets        = aws_subnet.private_subnets[*].id
+  existing_security_groups       = []
+  internal                       = false
+  certificate_arn                = aws_acm_certificate.jenkins.arn
+  jenkins_agent_secret_arns      = local.jenkins_agent_secret_arns
+  create_ec2_fleet_plugin_policy = true
+
+  # Build Farms
+  build_farm_subnets = aws_subnet.private_subnets[*].id
+
+  build_farm_compute = local.build_farm_compute
+
+  build_farm_fsx_openzfs_storage = local.build_farm_fsx_openzfs_storage
+  # Artifacts
+  artifact_buckets = {
+    builds : {
+      name                 = "game-builds"
+      enable_force_destroy = true
+
+      tags = {
+        Name = "game-builds"
+      }
+    },
+  }
+
+  depends_on = [aws_ecs_cluster.build_pipeline_cluster, aws_acm_certificate_validation.jenkins]
+}

--- a/modules/jenkins/examples/complete/main.tf
+++ b/modules/jenkins/examples/complete/main.tf
@@ -4,8 +4,8 @@
 # Shared ECS Cluster for Services
 ##########################################
 
-resource "aws_ecs_cluster" "build_pipeline_cluster" {
-  name = "build-pipeline-cluster"
+resource "aws_ecs_cluster" "jenkins_cluster" {
+  name = "jenkins-cluster"
 
   setting {
     name  = "containerInsights"
@@ -14,7 +14,7 @@ resource "aws_ecs_cluster" "build_pipeline_cluster" {
 }
 
 resource "aws_ecs_cluster_capacity_providers" "providers" {
-  cluster_name = aws_ecs_cluster.build_pipeline_cluster.name
+  cluster_name = aws_ecs_cluster.jenkins_cluster.name
 
   capacity_providers = ["FARGATE"]
 
@@ -32,14 +32,14 @@ resource "aws_ecs_cluster_capacity_providers" "providers" {
 module "jenkins" {
   source = "../.."
 
-  cluster_name                   = aws_ecs_cluster.build_pipeline_cluster.name
-  vpc_id                         = aws_vpc.build_pipeline_vpc.id
+  cluster_name                   = aws_ecs_cluster.jenkins_cluster.name
+  vpc_id                         = aws_vpc.jenkins_vpc.id
   jenkins_alb_subnets            = aws_subnet.public_subnets[*].id
   jenkins_service_subnets        = aws_subnet.private_subnets[*].id
   existing_security_groups       = []
   internal                       = false
   certificate_arn                = aws_acm_certificate.jenkins.arn
-  jenkins_agent_secret_arns      = local.jenkins_agent_secret_arns
+  jenkins_agent_secret_arns      = var.jenkins_agent_secret_arns
   create_ec2_fleet_plugin_policy = true
 
   # Build Farms
@@ -60,5 +60,5 @@ module "jenkins" {
     },
   }
 
-  depends_on = [aws_ecs_cluster.build_pipeline_cluster, aws_acm_certificate_validation.jenkins]
+  depends_on = [aws_ecs_cluster.jenkins_cluster, aws_acm_certificate_validation.jenkins]
 }

--- a/modules/jenkins/examples/complete/variables.tf
+++ b/modules/jenkins/examples/complete/variables.tf
@@ -1,0 +1,10 @@
+variable "fully_qualified_domain_name" {
+  type        = string
+  description = "The fully qualified domain name (FQDN) to be used for jenkins"
+}
+
+variable "jenkins_agent_secret_arns" {
+  type        = list(string)
+  description = "A list of secretmanager ARNs (wildcards allowed) that contain any secrets which need to be accessed by the Jenkins service."
+  default     = null
+}

--- a/modules/jenkins/examples/complete/variables.tf
+++ b/modules/jenkins/examples/complete/variables.tf
@@ -1,10 +1,10 @@
 variable "fully_qualified_domain_name" {
   type        = string
-  description = "The fully qualified domain name (FQDN) to be used for jenkins"
+  description = "A fully qualified domain name (FQDN) to be used for jenkins. A record will be created on the hosted zone with the following patterns 'jenkins.<your_fqdn>'"
 }
 
 variable "jenkins_agent_secret_arns" {
   type        = list(string)
   description = "A list of secretmanager ARNs (wildcards allowed) that contain any secrets which need to be accessed by the Jenkins service."
-  default     = null
+  default     = []
 }

--- a/modules/jenkins/examples/complete/versions.tf
+++ b/modules/jenkins/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.62.0"
+      version = "5.66.0"
     }
   }
 }

--- a/modules/jenkins/examples/complete/versions.tf
+++ b/modules/jenkins/examples/complete/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.62.0"
+    }
+  }
+}

--- a/modules/jenkins/examples/complete/vpc.tf
+++ b/modules/jenkins/examples/complete/vpc.tf
@@ -1,0 +1,131 @@
+##########################################
+# VPC
+##########################################
+
+resource "aws_vpc" "build_pipeline_vpc" {
+  cidr_block = local.vpc_cidr_block
+  tags = merge(local.tags,
+    {
+      Name = "build-pipeline-vpc"
+    }
+  )
+  enable_dns_hostnames = true
+  #checkov:skip=CKV2_AWS_11: VPC flow logging disabled by design
+}
+
+# Set default SG to restrict all traffic
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.build_pipeline_vpc.id
+}
+
+##########################################
+# Subnets
+##########################################
+
+resource "aws_subnet" "public_subnets" {
+  count             = length(local.public_subnet_cidrs)
+  vpc_id            = aws_vpc.build_pipeline_vpc.id
+  cidr_block        = element(local.public_subnet_cidrs, count.index)
+  availability_zone = element(local.azs, count.index)
+
+  tags = merge(local.tags,
+    {
+      Name = "pub-subnet-${count.index + 1}"
+    }
+  )
+}
+
+resource "aws_subnet" "private_subnets" {
+  count             = length(local.private_subnet_cidrs)
+  vpc_id            = aws_vpc.build_pipeline_vpc.id
+  cidr_block        = element(local.private_subnet_cidrs, count.index)
+  availability_zone = element(local.azs, count.index)
+
+  tags = merge(local.tags,
+    {
+      Name = "pvt-subnet-${count.index + 1}"
+    }
+  )
+}
+
+##########################################
+# Internet Gateway
+##########################################
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.build_pipeline_vpc.id
+  tags = merge(local.tags,
+    {
+      Name = "build-pipeline-igw"
+    }
+  )
+}
+
+##########################################
+# Route Tables & NAT Gateway
+##########################################
+
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.build_pipeline_vpc.id
+
+  # public route to the internet
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = merge(local.tags,
+    {
+      Name = "build-pipeline-public-rt"
+    }
+  )
+}
+
+resource "aws_route_table_association" "public_rt_asso" {
+  count          = length(aws_subnet.public_subnets)
+  route_table_id = aws_route_table.public_rt.id
+  subnet_id      = aws_subnet.public_subnets[count.index].id
+}
+
+resource "aws_eip" "nat_gateway_eip" {
+  depends_on = [aws_internet_gateway.igw]
+  #checkov:skip=CKV2_AWS_19:EIP associated with NAT Gateway through association ID
+  tags = merge(local.tags,
+    {
+      Name = "build-pipeline-nat-eip"
+    }
+  )
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.build_pipeline_vpc.id
+
+  # route to the internet through NAT gateway
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.nat_gateway.id
+  }
+
+  tags = merge(local.tags,
+    {
+      Name = "build-pipeline-private-rt"
+    }
+  )
+}
+
+resource "aws_route_table_association" "private_rt_asso" {
+  count          = length(aws_subnet.private_subnets)
+  route_table_id = aws_route_table.private_rt.id
+  subnet_id      = aws_subnet.private_subnets[count.index].id
+}
+
+# tflint-ignore: terraform_required_providers
+resource "aws_nat_gateway" "nat_gateway" {
+  allocation_id = aws_eip.nat_gateway_eip.id
+  subnet_id     = aws_subnet.public_subnets[0].id
+  tags = merge(local.tags,
+    {
+      Name = "build-pipeline-nat"
+    }
+  )
+}

--- a/samples/simple-build-pipeline/README.md
+++ b/samples/simple-build-pipeline/README.md
@@ -6,6 +6,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.66.0 |
 
+
 ## Providers
 
 | Name | Version |

--- a/samples/simple-build-pipeline/dns.tf
+++ b/samples/simple-build-pipeline/dns.tf
@@ -9,7 +9,7 @@ data "aws_route53_zone" "root" {
 
 resource "aws_route53_record" "jenkins" {
   zone_id = data.aws_route53_zone.root.id
-  name    = data.aws_route53_zone.root.name
+  name    = "jenkins.${data.aws_route53_zone.root.name}"
   type    = "A"
   alias {
     name                   = module.jenkins.jenkins_alb_dns_name


### PR DESCRIPTION
**Issue number:** 176

## Summary

Adds simple, but complete, example of deploying Jenkins on its own.

### Changes

Adds simple, but complete, example of deploying Jenkins on its own.
Fixes Jenkins Route53 record name to properly align with certificate

### User experience

Users now have a simple example demonstrating how to deploy Jenkins on its own

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.