### PR TITLE
Set ASP.NET Core runtime environment

### DIFF
--- a/modules/unreal/horde/ecs.tf
+++ b/modules/unreal/horde/ecs.tf
@@ -87,6 +87,10 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
           name  = "Horde__adminClaimValue"
           value = var.admin_claim_value
         },
+        {
+          name  = "ASPNETCORE_ENVIRONMENT"
+          value = var.environment
+        }
       ]
       logConfiguration = {
         logDriver = "awslogs"

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -21,8 +21,8 @@ variable "project_prefix" {
 
 variable "environment" {
   type        = string
-  description = "The current environment (e.g. dev, prod, etc.)"
-  default     = "dev"
+  description = "The current environment (e.g. Development, Staging, Production, etc.). This will tag ressources and set ASPNETCORE_ENVIRONMENT variable."
+  default     = "Development"
 }
 
 variable "tags" {


### PR DESCRIPTION

## Summary

### Changes

Use the environment variable to set the ASP.NET Core runtime environment for horde server.

### User experience

Admin can now see that horde server is running in the desired runtime environment when looking at the container logs.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.