### PR TITLE
Adding TRUST_PROXY to the Auth Service environment variables so that …

### DIFF
--- a/modules/perforce/helix-authentication-service/main.tf
+++ b/modules/perforce/helix-authentication-service/main.tf
@@ -83,7 +83,11 @@ resource "aws_ecs_task_definition" "helix_authentication_service_task_definition
           name  = "ADMIN_ENABLED"
           value = var.enable_web_based_administration ? "true" : "false"
         },
-
+        {
+          name = "TRUST_PROXY"
+          value = "true"
+        },
+        
         ],
         var.enable_web_based_administration ? [
           {


### PR DESCRIPTION
…it works behind a load balancer

#fixes 293

**Issue number: 293**

## Summary

### Changes

> Please provide a summary of what's being changed

Adding TRUST_PROXY to the Auth Service environment variables so that it works behind a load balancer,

### User experience

> Please share what the user experience looks like before and after this change

Helix Auth Service will work behind a load balancer now

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

Yes, it will recreate the auth ECS service when run. 

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.