### PR TITLE
fix(windows packer): Added install_git variable back

### DIFF
--- a/assets/packer/build-agents/windows/windows.pkr.hcl
+++ b/assets/packer/build-agents/windows/windows.pkr.hcl
@@ -52,6 +52,11 @@ variable "install_vs_tools" {
   default = true
 }
 
+variable "install_git" {
+  type = bool
+  default = true
+}
+
 variable "public_key" {
   type = string
 }
@@ -90,7 +95,7 @@ source "amazon-ebs" "base" {
   winrm_insecure = true
   winrm_username = "Administrator"
   winrm_use_ssl = true
-  winrm_timeout = "1h"
+  winrm_timeout = "15m"
   user_data_file = "./userdata.ps1"
 
   # network specific details


### PR DESCRIPTION
**Issue number:**
Closes #308 

## Summary

Creates `install_git` variable and defaults to True.

### Changes

> Please provide a summary of what's being changed

See summary.

### User experience

> Please share what the user experience looks like before and after this change

Users can disable Git installation on Windows build agent AMI with a variable.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.