### PR TITLE
Adding "helix_core_instance_id" to the "helix-core" module outputs.tf…

### DIFF
--- a/modules/perforce/helix-core/outputs.tf
+++ b/modules/perforce/helix-core/outputs.tf
@@ -27,3 +27,8 @@ output "helix_core_super_user_password_secret_arn" {
   value       = var.helix_core_super_user_password_secret_arn == null ? awscc_secretsmanager_secret.helix_core_super_user_password[0].secret_id : var.helix_core_super_user_password_secret_arn
   description = "The ARN of the AWS Secrets Manager secret holding your Helix Core super user's password."
 }
+
+output "helix_core_instance_id" {
+  value       = aws_instance.helix_core_instance.id
+  description = "Instance ID for the Helix Core instance"
+}


### PR DESCRIPTION
… file

resolves #315

**Issue number:**

## Summary

### Changes

> Please provide a summary of what's being changed

Adding "helix_core_instance_id" to the "helix-core" module outputs.tf

### User experience

> Please share what the user experience looks like before and after this change

User can now use `aws_instance.helix_core_instance.id` for things like mounting more EBS volumes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

No. 
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.