### PR TITLE
fix: improve stability of build agent packer scripts, remove variables that aren't needed

### DIFF
--- a/assets/packer/build-agents/linux/amazon-linux-2023-arm64.pkr.hcl
+++ b/assets/packer/build-agents/linux/amazon-linux-2023-arm64.pkr.hcl
@@ -12,10 +12,6 @@ variable "region" {
     default = "us-west-2"
 }
 
-variable "profile" {
-  type = string
-}
-
 variable "vpc_id" {
   type = string
 }

--- a/assets/packer/build-agents/linux/install_common.al2023.sh
+++ b/assets/packer/build-agents/linux/install_common.al2023.sh
@@ -25,7 +25,7 @@ echo "Updating packages..."
 sudo yum update -y
 echo "Installing packages..."
 sudo yum -y groupinstall "Development Tools"
-sudo yum install -y awscli java-11-amazon-corretto-headless java-11-amazon-corretto-devel libarchive libarchive-devel unzip cmake python3 python3-pip python3-requests clang lld git openssl libcurl-devel openssl-devel uuid-devel zlib-devel pulseaudio-libs-devel jq freetype-devel libsndfile-devel python3 jq libX11-devel libXcursor-devel libXinerama-devel mesa-libGL-devel mesa-libGLU-devel libudev-devel libXi-devel libXrandr-devel dos2unix
+sudo dnf install -y awscli java-11-amazon-corretto-headless java-11-amazon-corretto-devel libarchive libarchive-devel unzip cmake python3 python3-pip python3-requests clang lld git openssl libcurl-devel openssl-devel uuid-devel zlib-devel pulseaudio-libs-devel jq freetype-devel libsndfile-devel python3 jq libX11-devel libXcursor-devel libXinerama-devel mesa-libGL-devel mesa-libGLU-devel libudev-devel libXi-devel libXrandr-devel dos2unix
 sudo pip install boto3 botocore scons
 if [ "$(uname -p)" == "x86_64" ]; then
     sudo yum install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm

--- a/assets/packer/build-agents/linux/install_common.ubuntu.sh
+++ b/assets/packer/build-agents/linux/install_common.ubuntu.sh
@@ -26,7 +26,7 @@ echo "deb [signed-by=/usr/share/keyrings/corretto-keyring.gpg] https://apt.corre
 echo "Updating apt.."
 sudo apt-get -o DPkg::Lock::Timeout=180 update -y
 echo "Installing packages..."
-sudo apt-get install -y nfs-common libarchive-tools unzip cmake build-essential python3 python3-pip python3-requests python3-botocore clang lld git openssl libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev scons jq libsdl2-mixer-dev libsdl2-image-dev libsdl2-dev libfreetype-dev libsndfile1-dev libopenal-dev python3 jq libx11-dev libxcursor-dev libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libudev-dev libxi-dev libxrandr-dev java-11-amazon-corretto-jdk dos2unix
+sudo apt-get -o DPkg::Lock::Timeout=180 install -y nfs-common libarchive-tools unzip cmake build-essential python3 python3-pip python3-requests python3-botocore clang lld git openssl libcurl4-openssl-dev libssl-dev uuid-dev zlib1g-dev libpulse-dev scons jq libsdl2-mixer-dev libsdl2-image-dev libsdl2-dev libfreetype-dev libsndfile1-dev libopenal-dev python3 jq libx11-dev libxcursor-dev libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libudev-dev libxi-dev libxrandr-dev java-11-amazon-corretto-jdk dos2unix
 sudo pip install boto3
 echo "Installing AWS cli..."
 curl "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip" -o "awscliv2.zip"

--- a/assets/packer/build-agents/linux/install_octobuild.ubuntu.x86_64.sh
+++ b/assets/packer/build-agents/linux/install_octobuild.ubuntu.x86_64.sh
@@ -2,7 +2,8 @@
 # Install octobuild on Ubuntu, x86_64 only
 #  (octobuild does not seem to have packages available for aarch64 at the moment)
 # Requires common tools to be installed first.
-curl -1sLf 'https://dl.cloudsmith.io/public/octobuild/octobuild/setup.deb.sh' | sudo -E bash
 sudo apt-get -o DPkg::Lock::Timeout=180 update -y
+sudo NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=180 install -y apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/octobuild/octobuild/setup.deb.sh' | sudo -E bash
 sudo NEEDRESTART_MODE=a DEBIAN_FRONTEND=noninteractive apt-get -o DPkg::Lock::Timeout=180 install -y octobuild
 sudo mkdir -p /etc/octobuild

--- a/assets/packer/build-agents/windows/windows.pkr.hcl
+++ b/assets/packer/build-agents/windows/windows.pkr.hcl
@@ -118,9 +118,6 @@ build {
   provisioner "powershell" {
     elevated_user = "Administrator"
     elevated_password = build.Password
-    environment_vars = [
-      "INSTALL_GIT=${var.install_git}"
-    ]
     script           = "./base_setup.ps1"
   }
 

--- a/assets/packer/build-agents/windows/windows.pkr.hcl
+++ b/assets/packer/build-agents/windows/windows.pkr.hcl
@@ -90,7 +90,7 @@ source "amazon-ebs" "base" {
   winrm_insecure = true
   winrm_username = "Administrator"
   winrm_use_ssl = true
-  winrm_timeout = "1h"
+  winrm_timeout = "15m"
   user_data_file = "./userdata.ps1"
 
   # network specific details


### PR DESCRIPTION
**Issue number:** Closes #308 

## Summary

### Changes

This PR does two things:
1. It improves the stability of build agent packer scripts, mainly by setting dpkg timeout parameters that ensure that dpkg locks (e.g. those acquired by SSM automation) don't impede installation of packages (on Ubuntu) and using `dnf` instead of `yum` (on Amazon Linux 2023).
2. It removes configuration variables that weren't used.
3. It lowers the [WinRM connection timeout](https://developer.hashicorp.com/packer/docs/communicators/winrm#winrm_timeout) from 1 hour to 15 minutes, to give faster feedback in case firewalls are blocking WinRM connections.

### User experience

Only change in user experience is that there should now be fewer packer build failures.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

I checked, but documentation changes are not necessary for this PR.

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.