### PR TITLE
enhancement: install requirements for (auto)mounting FSx volumes on Windows build agents

### DIFF
--- a/assets/packer/build-agents/windows/README.md
+++ b/assets/packer/build-agents/windows/README.md
@@ -36,6 +36,10 @@ Currently this AMI is designed to work with our Jenkins module. This is why it c
 - OpenJDK used by Jenkins agents
 - Git
 - OpenSSH
+- Python3
+    - Botocore
+    - Boto3
+- Client for Network File System (NFS)
 - Windows Development Kit and Debugging Tools
 - Visual Studio 2022 Build Tools
     - VCTools Workload; Include Recommended

--- a/assets/packer/build-agents/windows/base_setup.ps1
+++ b/assets/packer/build-agents/windows/base_setup.ps1
@@ -44,6 +44,17 @@ catch {
 }
 
 try {
+    # Python
+    Write "Installing Python, botocore, boto3"
+    choco install -y  --no-progress python
+    refreshenv
+    pip install botocore boto3
+}
+catch {
+    Write "Failed to install Python, botocore, boto3"
+}
+
+try {
     Write Get-Disk | Where-Object partitionstyle -EQ 'raw'
     Get-Disk | Where-Object partitionstyle -EQ \"raw\" | Initialize-Disk -PartitionStyle GPT -PassThru | New-Partition -AssignDriveLetter -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel \"Data Drive\" -Confirm:$false
 }

--- a/assets/packer/build-agents/windows/base_setup.ps1
+++ b/assets/packer/build-agents/windows/base_setup.ps1
@@ -35,6 +35,15 @@ catch {
 }
 
 try {
+    # Installing Client for NFS
+    Write "Installing Client for NFS"
+    Install-WindowsFeature NFS-Client
+}
+catch {
+    Write "Failed to install Client for NFS"
+}
+
+try {
     Write Get-Disk | Where-Object partitionstyle -EQ 'raw'
     Get-Disk | Where-Object partitionstyle -EQ \"raw\" | Initialize-Disk -PartitionStyle GPT -PassThru | New-Partition -AssignDriveLetter -UseMaximumSize | Format-Volume -FileSystem NTFS -NewFileSystemLabel \"Data Drive\" -Confirm:$false
 }


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

This installs the following necessary requirements for (auto)mounting FSx volumes on Windows build agents:
* NFS-Client Windows feature
* Python, botocore, boto3 (required for FSx automounter script)

### User experience

Before: users would have to manually install the required packages after building the AMI

After: users won't have to install required packages after building the AMI

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.