### PR TITLE
ci: add pr-rebase.yaml

### DIFF
--- a/.github/workflows/pr-rebase.yml
+++ b/.github/workflows/pr-rebase.yml
@@ -2,10 +2,15 @@ name: Automatic Rebase
 on:
   issue_comment:
     types: [created]
+permissions:
+  contents: read
 jobs:
   rebase:
     name: Rebase
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/rebase') || contains(github.event.comment.body, '/autosquash')) && github.event.comment.author_association == 'MEMBER'
     steps:
       - name: Checkout the latest code

--- a/.github/workflows/pr-rebase.yml
+++ b/.github/workflows/pr-rebase.yml
@@ -1,0 +1,19 @@
+name: Automatic Rebase
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  rebase:
+    name: Rebase
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != '' && (contains(github.event.comment.body, '/rebase') || contains(github.event.comment.body, '/autosquash')) && github.event.comment.author_association == 'MEMBER'
+    steps:
+      - name: Checkout the latest code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.BOT_PAT }}
+          fetch-depth: 0
+      - name: Automatic Rebase
+        uses: cirrus-actions/rebase@1.8
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOT_PAT }}


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes
- Adds a new GitHub workflow that rebases PR branch onto main when triggered manually.
- The workflow uses [a pre-built 3rd party action](https://github.com/marketplace/actions/automatic-rebase).

### User experience
> Please share what the user experience looks like before and after this change
- When a rebase is needed, add PR comment `/rebase` which will trigger workflow to rebase the current branch onto main.
- Ability to trigger workflow is restricted to members of the GitHub Org. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.