### PR TITLE
feat(jenkins): Adds GHA deployment workflow

### DIFF
--- a/.github/workflows/jenkins-deployment.yml
+++ b/.github/workflows/jenkins-deployment.yml
@@ -1,0 +1,186 @@
+name: Jenkins Deployment Test
+
+env:
+  TF_VAR_fully_qualified_domain_name: ${{ secrets.CI_FULLY_QUALIFIED_DOMAIN_NAME }}
+  STATE_BUCKET_NAME: ${{ secrets.TF_REMOTE_STATE_BUCKET_NAME }}
+
+# Triggers on any changes to modules/jenkins
+on:
+  pull_request: # change to pull_request before publish
+    paths:
+      - 'modules/jenkins/**'
+  #      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+  issues: write
+
+jobs:
+  # Plan: Generates a tf plan of the deployment and posts it as a comment in the triggering PR
+  plan:
+    runs-on: ubuntu-latest
+    environment: aws-ci
+    permissions:
+      id-token: write
+      issues: write
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: modules/jenkins/examples/complete
+    steps:
+      # Retrieve necessary AWS permissions
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ vars.AWS_REGION }}
+      # Checkout Repository
+      - name: Checkout Git Repository
+        uses: actions/checkout@v3.0.0
+        with:
+          ref: ${{ github.ref }}
+      # Install Terraform
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.6.3
+      # Inject remote state block
+      # This is required to enable remote state
+      - name: Inject Remote State
+        run: |
+          cat > backend.tf << EOF
+          terraform {
+            backend "s3" {
+            }
+          }
+      # Initialize S3 remote state
+      # The triggering commit hash is used as the key of the remote state
+      - name: Terraform init
+        id: init
+        run: |
+          terraform init -backend-config="bucket=${STATE_BUCKET_NAME}" -backend-config="key=${{ github.sha }}" -backend-config="region=${{ vars.AWS_REGION }}"
+
+      # Generate tf plan
+      - name: Terraform plan
+        id: plan
+        run: |
+          terraform plan -no-color
+
+      # Post the tf plan as a comment in the triggering PR
+      - name: Update Pull Request
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `#### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+            <details><summary>Show Plan</summary>
+
+            \`\`\`\n
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+
+            </details>
+
+            *Pushed by: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            })
+
+  # Deploy: After manual approval, deploys the solution to the designated AWS account
+  deploy:
+    needs: [ plan ]
+    environment: aws-ci
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: modules/jenkins/examples/complete
+    steps:
+      # Checkout Repository
+      - name: Checkout Git Repository
+        uses: actions/checkout@v3.0.0
+        with:
+          ref: ${{ github.ref }}
+      # Retrieve necessary AWS permissions
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ vars.AWS_REGION }}
+      # Install Terraform
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.6.3
+      # Inject remote state block
+      # This is required to enable remote state
+      - name: Inject Remote State
+        run: |
+          cat > backend.tf << EOF
+          terraform {
+            backend "s3" {
+            }
+          }
+      # Initialize S3 remote state
+      # The triggering commit hash is used as the key of the remote state
+      - name: Terraform init
+        id: init
+        run: |
+          terraform init -backend-config="bucket=${STATE_BUCKET_NAME}" -backend-config="key=${{ github.sha }}" -backend-config="region=${{ vars.AWS_REGION }}"
+
+      # Deploys the solution
+      - name: Terraform apply
+        run: |
+          terraform apply -auto-approve
+
+  # Destroy: After manual approval, destroy the solution in the designated AWS account
+  destroy:
+    needs: [ deploy ]
+    runs-on: ubuntu-latest
+    environment: aws-ci
+    defaults:
+      run:
+        working-directory: modules/jenkins/examples/complete
+    steps:
+      # Checkout Repository
+      - name: Checkout Git Repository
+        uses: actions/checkout@v3.0.0
+        with:
+          ref: ${{ github.ref }}
+      # Retrieve necessary AWS permissions
+      - name: configure aws credentials
+        uses: aws-actions/configure-aws-credentials@v1.7.0
+        with:
+          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ vars.AWS_REGION }}
+      # Install Terraform
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.6.3
+      # Inject remote state block
+      # This is required to enable remote state
+      - name: Inject Remote State
+        run: |
+          cat > backend.tf << EOF
+          terraform {
+            backend "s3" {
+            }
+          }
+      # Initialize S3 remote state
+      # The triggering commit hash is used as the key of the remote state
+      - name: Terraform init
+        id: init
+        run: |
+          terraform init -backend-config="bucket=${STATE_BUCKET_NAME}" -backend-config="key=${{ github.sha }}" -backend-config="region=${{ vars.AWS_REGION }}"
+      # Destroys the solution
+      - name: Terraform Destroy
+        run: |
+          terraform destroy -auto-approve

--- a/modules/jenkins/examples/complete/main.tf
+++ b/modules/jenkins/examples/complete/main.tf
@@ -41,6 +41,10 @@ module "jenkins" {
   certificate_arn                = aws_acm_certificate.jenkins.arn
   jenkins_agent_secret_arns      = var.jenkins_agent_secret_arns
   create_ec2_fleet_plugin_policy = true
+  enable_jenkins_alb_access_logs = false
+  #checkov:skip=CKV_AWS_150:Disabling to allow for automated destroy during test deploys
+  enable_jenkins_alb_deletion_protection = false
+  enable_default_efs_backup_plan         = false
 
   # Build Farms
   build_farm_subnets = aws_subnet.private_subnets[*].id

--- a/modules/jenkins/examples/complete/versions.tf
+++ b/modules/jenkins/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.66.0"
+      version = "5.70.0"
     }
   }
 }

--- a/modules/jenkins/examples/complete/vpc.tf
+++ b/modules/jenkins/examples/complete/vpc.tf
@@ -109,9 +109,9 @@ resource "aws_route_table" "private_rt" {
 
 # route to the internet through NAT gateway
 resource "aws_route" "private_rt_nat_gateway" {
-  route_table_id            = aws_route_table.private_rt.id
-  destination_cidr_block    = "0.0.0.0/0"
-  nat_gateway_id            = aws_nat_gateway.nat_gateway.id
+  route_table_id         = aws_route_table.private_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat_gateway.id
 }
 
 resource "aws_route_table_association" "private_rt_asso" {


### PR DESCRIPTION
**Issue number:**

## Summary

Adds a Github Actions workflow to plan, deploy and destroy the jenkins complete example template. This workflow triggers on any changes to `modules/jenkins/*`. Some best practice features have been disabled as they cause the automated destruction of the solution to fail.

### Changes

- Adds a Github Actions workflow that:
  - Triggers on any PR that changes `modules/jenkins/*`
  - Prepares environment for terraform
  - Runs `terraform plan` and posts the output as a comment in the triggering PR
  - After manual approval, deploys the solution into the `cloud-game-development+ci` AWS account
  - After manual approval, destroys the solution in the `cloud-game-development+ci` AWS account
- Disables the following features in the `modules/jenkins/examples/complete` template to allow for automated destruction of solution:
  - ALB access logs (`terraform destroy` cannot delete s3 buckets that are not empty)
  - ALB deletion protection (`terraform destroy` cannot delete the ALB if deletion protection is enabled)
  - EFS backup plan (backup plans are not required when testing module as no data should be stored in a test environment)

### User experience

These changes will allow the repository maintainers to more easily test changes made to the Jenkins module. Deployment and Destruction of environments are done based on manual approval steps, so use of this workflow is optional.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.