### PR TITLE
chore: adds triage label to our issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report a reproducible bug to help us improve
 title: "Bug: TITLE"
-labels: ["bug"]
+labels: ["bug", "triage"]
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation_improvements.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_improvements.yml
@@ -1,7 +1,7 @@
 name: Documentation improvements
 description: Suggest a documentation update
 title: "Docs: TITLE"
-labels: ["documentation"]
+labels: ["documentation", "triage"]
 body:
   - type: textarea
     id: search_area

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,7 @@
 name: Feature request
 description: Suggest an idea for Cloud Game Development Toolkit
 title: "Feature request: TITLE"
-labels: ["feature-request"]
+labels: ["feature-request", "triage"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
**Issue number:**
## Summary
### Changes

> Please provide a summary of what's being changed

- Modifies the issue template files so that the "triage" label is added by default when the issue templates are used.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.