### PR TITLE
fix(horde): allow inbound access to horde agents on ports 7000-7010 from other horde agents

### DIFF
--- a/modules/unreal/horde/sg.tf
+++ b/modules/unreal/horde/sg.tf
@@ -220,3 +220,14 @@ resource "aws_vpc_security_group_ingress_rule" "unreal_horde_service_inbound_age
   to_port                      = 443
   ip_protocol                  = "tcp"
 }
+
+# Horde agents allow inbound access from other agents
+resource "aws_vpc_security_group_ingress_rule" "unreal_horde_agents_inbound_agents" {
+  count                        = length(var.agents) > 0 ? 1 : 0
+  security_group_id            = aws_security_group.unreal_horde_agent_sg[0].id
+  description                  = "Allow inbound traffic to Horde Agents from other Horde Agents."
+  referenced_security_group_id = aws_security_group.unreal_horde_agent_sg[0].id
+  from_port                    = 7000
+  to_port                      = 7010
+  ip_protocol                  = "tcp"
+}


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

This adds a security group rule to the Horde Agents security group that allows inbound access on ports 7000-7010 from the same security group. This enables usage of UnrealBuildAccelerator.

### User experience

Prior to this change, when using UnrealBuildAccelerator, users would see only a single agent performing and completing actual work, visible as bars in UbaVisualizer that eventually turn green on that agent, whilst others remain grey. Tasks would eventually fail.

This changes fixes this, by allowing build agents to transfer files and context between each other, resulting in is builds being performed on multiple build agents successfully, and tasks not failing.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

Documentation changes not necessary for this change.

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.