### PR TITLE
chore: define nat gateway routes outside of aws_route_table resources in samples and modules

### DIFF
--- a/modules/jenkins/examples/complete/vpc.tf
+++ b/modules/jenkins/examples/complete/vpc.tf
@@ -100,17 +100,18 @@ resource "aws_eip" "nat_gateway_eip" {
 resource "aws_route_table" "private_rt" {
   vpc_id = aws_vpc.jenkins_vpc.id
 
-  # route to the internet through NAT gateway
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat_gateway.id
-  }
-
   tags = merge(local.tags,
     {
       Name = "jenkins-private-rt"
     }
   )
+}
+
+# route to the internet through NAT gateway
+resource "aws_route" "private_rt_nat_gateway" {
+  route_table_id            = aws_route_table.private_rt.id
+  destination_cidr_block    = "0.0.0.0/0"
+  nat_gateway_id            = aws_nat_gateway.nat_gateway.id
 }
 
 resource "aws_route_table_association" "private_rt_asso" {

--- a/modules/perforce/examples/complete/vpc.tf
+++ b/modules/perforce/examples/complete/vpc.tf
@@ -100,17 +100,18 @@ resource "aws_eip" "nat_gateway_eip" {
 resource "aws_route_table" "private_rt" {
   vpc_id = aws_vpc.perforce_vpc.id
 
-  # route to the internet through NAT gateway
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat_gateway.id
-  }
-
   tags = merge(local.tags,
     {
       Name = "perforce-private-rt"
     }
   )
+}
+
+# route to the internet through NAT gateway
+resource "aws_route" "private_rt_nat_gateway" {
+  route_table_id            = aws_route_table.private_rt.id
+  destination_cidr_block    = "0.0.0.0/0"
+  nat_gateway_id            = aws_nat_gateway.nat_gateway.id
 }
 
 resource "aws_route_table_association" "private_rt_asso" {

--- a/modules/unreal/horde/examples/complete/vpc.tf
+++ b/modules/unreal/horde/examples/complete/vpc.tf
@@ -92,17 +92,18 @@ resource "aws_eip" "nat_gateway_eip" {
 resource "aws_route_table" "private_rt" {
   vpc_id = aws_vpc.unreal_engine_horde_vpc.id
 
-  # route to the internet through NAT gateway
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat_gateway.id
-  }
-
   tags = merge(local.tags,
     {
       Name = "unreal-horde-private-rt"
     }
   )
+}
+
+# route to the internet through NAT gateway
+resource "aws_route" "private_rt_nat_gateway" {
+  route_table_id            = aws_route_table.private_rt.id
+  destination_cidr_block    = "0.0.0.0/0"
+  nat_gateway_id            = aws_nat_gateway.nat_gateway.id
 }
 
 resource "aws_route_table_association" "private_rt_asso" {

--- a/samples/simple-build-pipeline/vpc.tf
+++ b/samples/simple-build-pipeline/vpc.tf
@@ -100,17 +100,18 @@ resource "aws_eip" "nat_gateway_eip" {
 resource "aws_route_table" "private_rt" {
   vpc_id = aws_vpc.build_pipeline_vpc.id
 
-  # route to the internet through NAT gateway
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.nat_gateway.id
-  }
-
   tags = merge(local.tags,
     {
       Name = "build-pipeline-private-rt"
     }
   )
+}
+
+# route to the internet through NAT gateway
+resource "aws_route" "private_rt_nat_gateway" {
+  route_table_id            = aws_route_table.private_rt.id
+  destination_cidr_block    = "0.0.0.0/0"
+  nat_gateway_id            = aws_nat_gateway.nat_gateway.id
 }
 
 resource "aws_route_table_association" "private_rt_asso" {


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

This change ensures that the NAT Gateway routes for private route tables are declared in `aws_route` resources, instead of through the `aws_route_table` resource that creates the route table. The rationale for this is that the way it's done now does not allow users to add their own routes to these route tables outside of the `aws_route_table` resource's route declarations.

### User experience

Users that are basing their infrastructure off of the samples and have their own routes defined for the private route tables will no longer see their additions getting removed by Terraform incorrectly.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

I have tested the changes for the Horde sample.

No changes in documentation are necessary.

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.