### PR TITLE
Gabeaws/docs/getting started updates

### DIFF
--- a/assets/packer/build-agents/linux/amazon-linux-2023-arm64.pkr.hcl
+++ b/assets/packer/build-agents/linux/amazon-linux-2023-arm64.pkr.hcl
@@ -14,10 +14,12 @@ variable "region" {
 
 variable "vpc_id" {
   type = string
+  default = null
 }
 
 variable "subnet_id" {
   type = string
+  default = null
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
**Issue number:** #355 

## Summary

Updates documentation for getting started with the simple build pipeline sample and adds missing defaults packer template.

### Changes

- added warnings regarding the region variable in packer templates as they default to `us-west-2` and can cause errors.
- Changed Packer commands to proper syntax in getting started docs
- Changed the `Note` admonition in the `Amazon Linux 2023 ARM based Amazon Machine Image` section to a warning, as not heading that admonition would cause the command to fail.
- Added defaults to the `vpc_id` and `subnet_id` variables in `amazon-linux-2023-arm64.pkr.hcl`, allowing Packer to default to the default VPC if no value is passed in.
- Renamed the `fully_qualified_domain_name` reference in`Step 5. Configure Simple Build Pipeline Variables` to `root_domain_name` to align with name change in code.
- Split `Step 5. Configure Simple Build Pipeline Variables` section into `local.tf` and `variables.tf` paragraphs to align with module structure.


### User experience

Fixes faulty code and clarifies sections which are most likely to cause issues for users.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.