### PR TITLE
fix: bash error causing build failure when running p4_configure.sh

### DIFF
--- a/assets/packer/perforce/helix-core/p4_configure.sh
+++ b/assets/packer/perforce/helix-core/p4_configure.sh
@@ -484,7 +484,7 @@ else
 fi
 
 # Check if the HELIX_AUTH_SERVICE_URL is empty. if not, configure Helix Authentication Extension
-if [-z $HELIX_AUTH_SERVICE_URL ]; then
+if [ -z $HELIX_AUTH_SERVICE_URL ]; then
   log_message "Helix Authentication Service URL was not provided. Skipping configuration."
 else
   log_message "Configuring Helix Authentication Extension against $HELIX_AUTH_SERVICE_URL"


### PR DESCRIPTION
## Summary

### Changes

This fixes a bash syntax issue when running the p4_configure.sh script.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.