### PR TITLE
chore: add external tls access to ALB + force cleanup resource flag

### DIFF
--- a/modules/unreal/horde/alb.tf
+++ b/modules/unreal/horde/alb.tf
@@ -237,6 +237,8 @@ resource "aws_s3_bucket" "unreal_horde_alb_access_logs_bucket" {
   count  = var.enable_unreal_horde_alb_access_logs && var.unreal_horde_alb_access_logs_bucket == null ? 1 : 0
   bucket = "${local.name_prefix}-alb-access-logs-${random_string.unreal_horde_alb_access_logs_bucket_suffix[0].result}"
 
+  force_destroy = var.enable_force_cleanup
+
   #checkov:skip=CKV_AWS_21: Versioning not necessary for access logs
   #checkov:skip=CKV_AWS_144: Cross-region replication not necessary for access logs
   #checkov:skip=CKV_AWS_145: KMS encryption with CMK not currently supported

--- a/modules/unreal/horde/asg.tf
+++ b/modules/unreal/horde/asg.tf
@@ -123,6 +123,8 @@ resource "aws_s3_bucket" "ansible_playbooks" {
   count  = length(var.agents) > 0 ? 1 : 0
   bucket = "unreal-horde-ansible-playbooks-${random_string.unreal_horde_ansible_playbooks_bucket_suffix[0].id}"
 
+  force_destroy = var.enable_force_cleanup
+
   #checkov:skip=CKV_AWS_144: Cross-region replication not necessary
   #checkov:skip=CKV_AWS_145: KMS encryption with CMK not currently supported
   #checkov:skip=CKV_AWS_18: S3 access logs not necessary

--- a/modules/unreal/horde/examples/complete/dns.tf
+++ b/modules/unreal/horde/examples/complete/dns.tf
@@ -46,6 +46,11 @@ resource "aws_acm_certificate" "unreal_engine_horde" {
   domain_name       = "horde.${data.aws_route53_zone.root.name}"
   validation_method = "DNS"
 
+  subject_alternative_names = [
+    "*.${data.aws_route53_zone.root.name}",
+    "*.horde.${data.aws_route53_zone.root.name}"
+  ]
+
   tags = {
     environment = "dev"
   }
@@ -63,6 +68,8 @@ resource "aws_route53_record" "unreal_engine_horde_cert" {
       record = dvo.resource_record_value
       type   = dvo.resource_record_type
     }
+    # skips the domain if it doesn't contain a wildcard
+    if length(regexall("\\*\\..+", dvo.domain_name)) > 0
   }
 
   allow_overwrite = true

--- a/modules/unreal/horde/sg.tf
+++ b/modules/unreal/horde/sg.tf
@@ -95,6 +95,18 @@ resource "aws_vpc_security_group_egress_rule" "unreal_horde_outbound_ipv6" {
   ip_protocol       = "-1" # semantically equivalent to all ports
 }
 
+
+# Inbound access to ALB from external traffic.
+resource "aws_vpc_security_group_ingress_rule" "unreal_horde_inbound_external_alb_traffic" {
+  count             = var.create_external_alb ? 1 : 0
+  security_group_id = aws_security_group.unreal_horde_external_alb_sg[0].id
+  description       = "Allow inbound web server traffic from Unreal Horde external ALB."
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = var.external_api_port
+  to_port           = var.external_api_port
+  ip_protocol       = "tcp"
+}
+
 # Inbound access to Containers from External ALB on API port
 resource "aws_vpc_security_group_ingress_rule" "unreal_horde_inbound_external_alb_api" {
   count                        = var.create_external_alb ? 1 : 0

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -38,7 +38,13 @@ variable "tags" {
 variable "debug" {
   type        = bool
   description = "Set this flag to enable ECS execute permissions on the Unreal Horde container and force new service deployments on Terraform apply."
-  default     = false
+  default     = true
+}
+
+variable "enable_force_cleanup" {
+  type        = bool
+  description = "Set this flag to true to enable force destroying of resources."
+  default     = true
 }
 
 ########################################
@@ -71,6 +77,13 @@ variable "container_name" {
   type        = string
   description = "The name of the Unreal Horde container."
   default     = "unreal-horde-container"
+  nullable    = false
+}
+
+variable "external_api_port" {
+  type        = number
+  description = "The external port for the Unreal Horde web server."
+  default     = 443
   nullable    = false
 }
 
@@ -165,7 +178,7 @@ variable "unreal_horde_alb_access_logs_prefix" {
 
 variable "enable_unreal_horde_alb_deletion_protection" {
   type        = bool
-  description = "Enables deletion protection for the Unreal Horde ALB. Defaults to true."
+  description = "Enables deletion protection for the Unreal Horde ALB. Defaults to false."
   default     = false
 }
 


### PR DESCRIPTION
I noticed that the horde example stack doesn't have internet access through the ALB due to the security group rules.
Also added a enable_force_cleanup variable to cleanup s3 buckets.

## Summary

### Changes
- Adds a flag to enable a clean stack deletion
- Enables public access to the horde server running on :443

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented


## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.