### PR TITLE
fix(horde): add JwtIssuer to ensure container retains agents on restart

### DIFF
--- a/modules/unreal/horde/ecs.tf
+++ b/modules/unreal/horde/ecs.tf
@@ -76,7 +76,11 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
         {
           name  = "Horde__databasePublicCert",
           value = "/app/config/global-bundle.pem"
-        }
+        },
+        {
+          name  = "Horde__jwtIssuer",
+          value = "https://${var.fully_qualified_domain_name}"
+        },
       ], local.horde_service_env)
       logConfiguration = {
         logDriver = "awslogs"


### PR DESCRIPTION

## Summary

### Changes

In order to retain agents on ECS container restart the `JwtIssuer` must be set to a value that won't change. By default horde uses `Dns.GetHostName()` which changes on restart.

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.