### PR TITLE
fix: Added service target group ARNs as outputs for HAS and Swarm

### DIFF
--- a/modules/perforce/helix-authentication-service/README.md
+++ b/modules/perforce/helix-authentication-service/README.md
@@ -6,16 +6,16 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.69.0 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | 1.16.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.72.1 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | 1.20.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 1.16.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.72.1 |
+| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 1.20.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
@@ -26,39 +26,39 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_group.helix_authentication_service_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_ecs_cluster.helix_authentication_service_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_cluster) | resource |
-| [aws_ecs_cluster_capacity_providers.helix_authentication_service_cluster_fargate_providers](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_cluster_capacity_providers) | resource |
-| [aws_ecs_service.helix_authentication_service](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_service) | resource |
-| [aws_ecs_task_definition.helix_authentication_service_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_task_definition) | resource |
-| [aws_iam_policy.helix_authentication_service_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.helix_authentication_service_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.helix_authentication_service_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.helix_authentication_service_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_role) | resource |
-| [aws_lb.helix_authentication_service_alb](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb) | resource |
-| [aws_lb_listener.helix_authentication_service_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.helix_authentication_service_alb_target_group](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_target_group) | resource |
-| [aws_s3_bucket.helix_authentication_service_alb_access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_lifecycle_configuration.access_logs_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_policy.alb_access_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.access_logs_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_security_group.helix_authentication_service_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_security_group.helix_authentication_service_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_vpc_security_group_egress_rule.helix_authentication_service_alb_outbound_service](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.helix_authentication_service_outbound_ipv4](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.helix_authentication_service_outbound_ipv6](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.helix_authentication_service_inbound_alb](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [awscc_secretsmanager_secret.helix_authentication_service_admin_password](https://registry.terraform.io/providers/hashicorp/awscc/1.16.1/docs/resources/secretsmanager_secret) | resource |
-| [awscc_secretsmanager_secret.helix_authentication_service_admin_username](https://registry.terraform.io/providers/hashicorp/awscc/1.16.1/docs/resources/secretsmanager_secret) | resource |
+| [aws_cloudwatch_log_group.helix_authentication_service_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecs_cluster.helix_authentication_service_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_cluster_capacity_providers.helix_authentication_service_cluster_fargate_providers](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/ecs_cluster_capacity_providers) | resource |
+| [aws_ecs_service.helix_authentication_service](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.helix_authentication_service_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_policy.helix_authentication_service_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.helix_authentication_service_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/iam_policy) | resource |
+| [aws_iam_role.helix_authentication_service_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/iam_role) | resource |
+| [aws_iam_role.helix_authentication_service_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/iam_role) | resource |
+| [aws_lb.helix_authentication_service_alb](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/lb) | resource |
+| [aws_lb_listener.helix_authentication_service_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.helix_authentication_service_alb_target_group](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/lb_target_group) | resource |
+| [aws_s3_bucket.helix_authentication_service_alb_access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.access_logs_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.alb_access_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.access_logs_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_security_group.helix_authentication_service_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/security_group) | resource |
+| [aws_security_group.helix_authentication_service_sg](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_egress_rule.helix_authentication_service_alb_outbound_service](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.helix_authentication_service_outbound_ipv4](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.helix_authentication_service_outbound_ipv6](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.helix_authentication_service_inbound_alb](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [awscc_secretsmanager_secret.helix_authentication_service_admin_password](https://registry.terraform.io/providers/hashicorp/awscc/1.20.0/docs/resources/secretsmanager_secret) | resource |
+| [awscc_secretsmanager_secret.helix_authentication_service_admin_username](https://registry.terraform.io/providers/hashicorp/awscc/1.20.0/docs/resources/secretsmanager_secret) | resource |
 | [random_string.helix_authentication_service](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
 | [random_string.helix_authentication_service_alb_access_logs_bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
-| [aws_ecs_cluster.helix_authentication_service_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/ecs_cluster) | data source |
-| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/elb_service_account) | data source |
-| [aws_iam_policy_document.access_logs_bucket_alb_write](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.helix_authentication_service_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.helix_authentication_service_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/region) | data source |
+| [aws_ecs_cluster.helix_authentication_service_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/ecs_cluster) | data source |
+| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/elb_service_account) | data source |
+| [aws_iam_policy_document.access_logs_bucket_alb_write](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.helix_authentication_service_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.helix_authentication_service_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -91,7 +91,7 @@ No modules.
 | <a name="input_internal"></a> [internal](#input\_internal) | Set this flag to true if you do not want the Helix Authentication Service load balancer to have a public IP. | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name attached to Helix Authentication Service module resources. | `string` | `"helix-auth-svc"` | no |
 | <a name="input_project_prefix"></a> [project\_prefix](#input\_project\_prefix) | The project prefix for this workload. This is appeneded to the beginning of most resource names. | `string` | `"cgd"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br/>  "iac-management": "CGD-Toolkit",<br/>  "iac-module": "helix-authentication-service",<br/>  "iac-provider": "Terraform"<br/>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br>  "iac-management": "CGD-Toolkit",<br>  "iac-module": "helix-authentication-service",<br>  "iac-provider": "Terraform"<br>}</pre> | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the existing VPC you would like to deploy Helix Authentication Service into. | `string` | n/a | yes |
 
 ## Outputs
@@ -103,4 +103,5 @@ No modules.
 | <a name="output_alb_zone_id"></a> [alb\_zone\_id](#output\_alb\_zone\_id) | The hosted zone ID of the Helix Authentication Service ALB |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the ECS cluster hosting helix\_authentication\_service |
 | <a name="output_service_security_group_id"></a> [service\_security\_group\_id](#output\_service\_security\_group\_id) | Security group associated with the ECS service running Helix Authentication Service |
+| <a name="output_target_group_arn"></a> [target\_group\_arn](#output\_target\_group\_arn) | The service target group for the Helix Authentication Service. |
 <!-- END_TF_DOCS -->

--- a/modules/perforce/helix-authentication-service/outputs.tf
+++ b/modules/perforce/helix-authentication-service/outputs.tf
@@ -10,7 +10,8 @@ output "alb_security_group_id" {
 
 output "cluster_name" {
   description = "Name of the ECS cluster hosting helix_authentication_service"
-  value       = var.cluster_name != null ? var.cluster_name : aws_ecs_cluster.helix_authentication_service_cluster[0].name
+  value = (var.cluster_name != null ? var.cluster_name :
+  aws_ecs_cluster.helix_authentication_service_cluster[0].name)
 }
 
 output "alb_dns_name" {
@@ -21,4 +22,9 @@ output "alb_dns_name" {
 output "alb_zone_id" {
   description = "The hosted zone ID of the Helix Authentication Service ALB"
   value       = aws_lb.helix_authentication_service_alb.zone_id
+}
+
+output "target_group_arn" {
+  value       = aws_lb_target_group.helix_authentication_service_alb_target_group.arn
+  description = "The service target group for the Helix Authentication Service."
 }

--- a/modules/perforce/helix-swarm/README.md
+++ b/modules/perforce/helix-swarm/README.md
@@ -6,14 +6,14 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.69.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.72.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.72.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
@@ -24,42 +24,42 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_group.helix_swarm_redis_service_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_cloudwatch_log_group.helix_swarm_service_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_ecs_cluster.helix_swarm_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_cluster) | resource |
-| [aws_ecs_cluster_capacity_providers.helix_swarm_cluster_fargate_providers](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_cluster_capacity_providers) | resource |
-| [aws_ecs_service.helix_swarm_service](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_service) | resource |
-| [aws_ecs_task_definition.helix_swarm_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_task_definition) | resource |
-| [aws_elasticache_cluster.swarm](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/elasticache_cluster) | resource |
-| [aws_elasticache_subnet_group.swarm](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/elasticache_subnet_group) | resource |
-| [aws_iam_policy.helix_swarm_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.helix_swarm_ssm_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.helix_swarm_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.helix_swarm_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_role) | resource |
-| [aws_lb.helix_swarm_alb](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb) | resource |
-| [aws_lb_listener.swarm_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.helix_swarm_alb_target_group](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_target_group) | resource |
-| [aws_s3_bucket.helix_swarm_alb_access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_lifecycle_configuration.access_logs_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_policy.alb_access_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.access_logs_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_security_group.helix_swarm_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_security_group.helix_swarm_elasticache_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_security_group.helix_swarm_service_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_vpc_security_group_egress_rule.helix_swarm_alb_outbound_service](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.helix_swarm_service_outbound_ipv4](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.helix_swarm_service_outbound_ipv6](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.helix_swarm_elasticache_ingress](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.helix_swarm_service_inbound_alb](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_cloudwatch_log_group.helix_swarm_redis_service_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.helix_swarm_service_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecs_cluster.helix_swarm_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_cluster_capacity_providers.helix_swarm_cluster_fargate_providers](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/ecs_cluster_capacity_providers) | resource |
+| [aws_ecs_service.helix_swarm_service](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.helix_swarm_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/ecs_task_definition) | resource |
+| [aws_elasticache_cluster.swarm](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/elasticache_cluster) | resource |
+| [aws_elasticache_subnet_group.swarm](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/elasticache_subnet_group) | resource |
+| [aws_iam_policy.helix_swarm_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.helix_swarm_ssm_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/iam_policy) | resource |
+| [aws_iam_role.helix_swarm_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/iam_role) | resource |
+| [aws_iam_role.helix_swarm_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/iam_role) | resource |
+| [aws_lb.helix_swarm_alb](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/lb) | resource |
+| [aws_lb_listener.swarm_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.helix_swarm_alb_target_group](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/lb_target_group) | resource |
+| [aws_s3_bucket.helix_swarm_alb_access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.access_logs_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.alb_access_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.access_logs_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_security_group.helix_swarm_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/security_group) | resource |
+| [aws_security_group.helix_swarm_elasticache_sg](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/security_group) | resource |
+| [aws_security_group.helix_swarm_service_sg](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_egress_rule.helix_swarm_alb_outbound_service](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.helix_swarm_service_outbound_ipv4](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.helix_swarm_service_outbound_ipv6](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.helix_swarm_elasticache_ingress](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.helix_swarm_service_inbound_alb](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [random_string.helix_swarm](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
 | [random_string.helix_swarm_alb_access_logs_bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
-| [aws_ecs_cluster.helix_swarm_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/ecs_cluster) | data source |
-| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/elb_service_account) | data source |
-| [aws_iam_policy_document.access_logs_bucket_alb_write](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.helix_swarm_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.helix_swarm_ssm_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/region) | data source |
+| [aws_ecs_cluster.helix_swarm_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/ecs_cluster) | data source |
+| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/elb_service_account) | data source |
+| [aws_iam_policy_document.access_logs_bucket_alb_write](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.helix_swarm_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.helix_swarm_ssm_policy](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.72.1/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -77,7 +77,7 @@ No modules.
 | <a name="input_enable_helix_swarm_alb_deletion_protection"></a> [enable\_helix\_swarm\_alb\_deletion\_protection](#input\_enable\_helix\_swarm\_alb\_deletion\_protection) | Enables deletion protection for the Helix Swarm ALB. Defaults to true. | `bool` | `true` | no |
 | <a name="input_enable_sso"></a> [enable\_sso](#input\_enable\_sso) | Set this to true if using SSO for Helix Swarm authentication. | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The current environment (e.g. dev, prod, etc.) | `string` | `"dev"` | no |
-| <a name="input_existing_redis_connection"></a> [existing\_redis\_connection](#input\_existing\_redis\_connection) | The connection specifications to use for an existing Redis deployment. | <pre>object({<br/>    host = string<br/>    port = number<br/>  })</pre> | `null` | no |
+| <a name="input_existing_redis_connection"></a> [existing\_redis\_connection](#input\_existing\_redis\_connection) | The connection specifications to use for an existing Redis deployment. | <pre>object({<br>    host = string<br>    port = number<br>  })</pre> | `null` | no |
 | <a name="input_existing_security_groups"></a> [existing\_security\_groups](#input\_existing\_security\_groups) | A list of existing security group IDs to attach to the Helix Swarm service load balancer. | `list(string)` | `[]` | no |
 | <a name="input_fully_qualified_domain_name"></a> [fully\_qualified\_domain\_name](#input\_fully\_qualified\_domain\_name) | The fully qualified domain name that Swarm should use for internal URLs. | `string` | `null` | no |
 | <a name="input_helix_swarm_alb_access_logs_bucket"></a> [helix\_swarm\_alb\_access\_logs\_bucket](#input\_helix\_swarm\_alb\_access\_logs\_bucket) | ID of the S3 bucket for Helix Swarm ALB access log storage. If access logging is enabled and this is null the module creates a bucket. | `string` | `null` | no |
@@ -98,7 +98,7 @@ No modules.
 | <a name="input_p4d_swarm_password_arn"></a> [p4d\_swarm\_password\_arn](#input\_p4d\_swarm\_password\_arn) | The ARN of the parameter or secret where the swarm user password is stored. | `string` | n/a | yes |
 | <a name="input_p4d_swarm_user_arn"></a> [p4d\_swarm\_user\_arn](#input\_p4d\_swarm\_user\_arn) | The ARN of the parameter or secret where the swarm user username is stored. | `string` | n/a | yes |
 | <a name="input_project_prefix"></a> [project\_prefix](#input\_project\_prefix) | The project prefix for this workload. This is appeneded to the beginning of most resource names. | `string` | `"cgd"` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br/>  "iac-management": "CGD-Toolkit",<br/>  "iac-module": "swarm",<br/>  "iac-provider": "Terraform"<br/>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br>  "iac-management": "CGD-Toolkit",<br>  "iac-module": "swarm",<br>  "iac-provider": "Terraform"<br>}</pre> | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the existing VPC you would like to deploy swarm into. | `string` | n/a | yes |
 
 ## Outputs
@@ -110,4 +110,5 @@ No modules.
 | <a name="output_alb_zone_id"></a> [alb\_zone\_id](#output\_alb\_zone\_id) | The hosted zone ID of the Swarm ALB |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | Name of the ECS cluster hosting Swarm |
 | <a name="output_service_security_group_id"></a> [service\_security\_group\_id](#output\_service\_security\_group\_id) | Security group associated with the ECS service running swarm |
+| <a name="output_target_group_arn"></a> [target\_group\_arn](#output\_target\_group\_arn) | The ARN of the Helix Swarm service target group. |
 <!-- END_TF_DOCS -->

--- a/modules/perforce/helix-swarm/outputs.tf
+++ b/modules/perforce/helix-swarm/outputs.tf
@@ -22,3 +22,8 @@ output "alb_zone_id" {
   description = "The hosted zone ID of the Swarm ALB"
   value       = aws_lb.helix_swarm_alb.zone_id
 }
+
+output "target_group_arn" {
+  value       = aws_lb_target_group.helix_swarm_alb_target_group.arn
+  description = "The ARN of the Helix Swarm service target group."
+}


### PR DESCRIPTION
**Issue number:**
N/A

## Summary
Small fix to expose ECS service target groups as outputs for Helix Swarm and Helix Core.

### Changes

> Please provide a summary of what's being changed

- Added Helix Swarm target group output: `target_group_arn`
- Added Helix Authentication Service target group output: `target_group_arn`

### User experience

> Please share what the user experience looks like before and after this change

Users looking to share an application load balancer across services can now leverage the output target groups to forward traffic to the underlying services.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.