### PR TITLE
fix: use provided admin password secret for Helix Authentication Service ADMIN_PASSWD, instead of the username secret

### DIFF
--- a/modules/perforce/helix-authentication-service/main.tf
+++ b/modules/perforce/helix-authentication-service/main.tf
@@ -134,7 +134,7 @@ resource "aws_ecs_task_definition" "helix_authentication_service_task_definition
         },
         {
           name      = "ADMIN_PASSWD"
-          valueFrom = var.helix_authentication_service_admin_password_secret_arn != null ? var.helix_authentication_service_admin_username_secret_arn : awscc_secretsmanager_secret.helix_authentication_service_admin_password[0].secret_id
+          valueFrom = var.helix_authentication_service_admin_password_secret_arn != null ? var.helix_authentication_service_admin_password_secret_arn : awscc_secretsmanager_secret.helix_authentication_service_admin_password[0].secret_id
         },
       ] : [],
       logConfiguration = {


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

This fixes an issue where if an admin password and admin username secret ARN were provided, the admin _username_ ARN would be used for the ADMIN_PASSWD environment variable, instead of the admin _password_. This meant that the username would be used as password in Helix Authentication Service's admin interface.

### User experience

> Please share what the user experience looks like before and after this change

Before: users would **not** be able to log in to Helix Authentication Service using the credentials they configured.

After: users would be able to log in to Helix Authentication Service using the credentials they configured.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.