### PR TITLE
fix: Minor adjustments to Horde module resource cleanup and documentation

### DIFF
--- a/docs/modules/unreal/horde/examples/complete.md
+++ b/docs/modules/unreal/horde/examples/complete.md
@@ -19,7 +19,7 @@ If you do not have a domain yet you can [register one through Route53](https://d
 
 If you already have a domain with a different domain registrar you can leverage Route53 for DNS services. [Please review the documentation for migrating to Route53 as your DNS provider.](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/MigratingDNS.html)
 
-If you own the domain: "example.com" this example will deploy Helix Core to "core.helix.example.com" and Helix Swarm to "swarm.helix.example.com" - this can be modified from the `dns.tf` file.
+If you own the domain: "example.com" this example will deploy Horde to "horde.example.com" - this can be modified from the `dns.tf` file.
 
 ### `github_credentials_secret_arn`
 

--- a/modules/perforce/examples/complete/main.tf
+++ b/modules/perforce/examples/complete/main.tf
@@ -155,6 +155,12 @@ resource "aws_lb_target_group" "perforce_web_services" {
   vpc_id      = aws_vpc.perforce_vpc.id
 }
 
+resource "aws_lb_target_group_attachment" "perforce_web_services" {
+  target_group_arn = aws_lb_target_group.perforce_web_services.arn
+  target_id        = aws_lb.perforce_web_services.arn
+  port = 443
+}
+
 # Default rule redirects to Helix Swarm
 resource "aws_lb_listener" "perforce_web_services" {
   load_balancer_arn = aws_lb.perforce_web_services.arn

--- a/modules/unreal/horde/alb.tf
+++ b/modules/unreal/horde/alb.tf
@@ -236,6 +236,7 @@ resource "random_string" "unreal_horde_alb_access_logs_bucket_suffix" {
 resource "aws_s3_bucket" "unreal_horde_alb_access_logs_bucket" {
   count  = var.enable_unreal_horde_alb_access_logs && var.unreal_horde_alb_access_logs_bucket == null ? 1 : 0
   bucket = "${local.name_prefix}-alb-access-logs-${random_string.unreal_horde_alb_access_logs_bucket_suffix[0].result}"
+  force_destroy = true
 
   #checkov:skip=CKV_AWS_21: Versioning not necessary for access logs
   #checkov:skip=CKV_AWS_144: Cross-region replication not necessary for access logs

--- a/modules/unreal/horde/asg.tf
+++ b/modules/unreal/horde/asg.tf
@@ -133,6 +133,7 @@ resource "aws_s3_bucket" "ansible_playbooks" {
 
   tags                = local.tags
   object_lock_enabled = true
+  force_destroy = true
 
 }
 


### PR DESCRIPTION
**Issue number:**
Closes #455 

## Summary

fix: Minor adjustments to Horde module resource cleanup and documentation. Adding ALB target group attachment for Perforce complete example.

### Changes

> Please provide a summary of what's being changed

- Adding `force_destroy = true` to ALB access logs bucket and Horde agent playbook bucket.
- Updating Horde documentation to remove erroneous Perforce references.
- Adding ALB attachment for Perforce Complete example.

### User experience

> Please share what the user experience looks like before and after this change

Simplified destruction process for Horde. Previously `terraform destroy` against Horde complete example would error out because access logs bucket and playbook bucket were not empty.

Attached Perforce web services ALB to correct target group for Perforce complete example.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.