### PR TITLE
fix: create_external_alb set to false shouldn't block internal SG ingress rule creation

### DIFF
--- a/modules/unreal/horde/sg.tf
+++ b/modules/unreal/horde/sg.tf
@@ -118,7 +118,7 @@ resource "aws_vpc_security_group_ingress_rule" "unreal_horde_inbound_external_al
 
 # Inbound access to Containers from Internal ALB on API port
 resource "aws_vpc_security_group_ingress_rule" "unreal_horde_inbound_internal_alb_api" {
-  count                        = var.create_external_alb ? 1 : 0
+  count                        = var.create_internal_alb ? 1 : 0
   security_group_id            = aws_security_group.unreal_horde_sg.id
   description                  = "Allow inbound web service traffic from Unreal Horde internal ALB."
   referenced_security_group_id = aws_security_group.unreal_horde_internal_alb_sg[0].id
@@ -128,7 +128,7 @@ resource "aws_vpc_security_group_ingress_rule" "unreal_horde_inbound_internal_al
 }
 
 resource "aws_vpc_security_group_ingress_rule" "unreal_horde_inbound_internal_alb_grpc" {
-  count                        = var.create_external_alb ? 1 : 0
+  count                        = var.create_internal_alb ? 1 : 0
   security_group_id            = aws_security_group.unreal_horde_sg.id
   description                  = "Allow inbound GRPC traffic from Unreal Horde internal ALB."
   referenced_security_group_id = aws_security_group.unreal_horde_internal_alb_sg[0].id


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

> Please provide a summary of what's being changed

If you set `create_external_alb` to `false`, this currently blocks the creation of the following ingress rules:
- `unreal_horde_inbound_internal_alb_api`
- `unreal_horde_inbound_internal_alb_grpc`

### User experience

> Please share what the user experience looks like before and after this change

Internal ingress rules would only be blocked when `create_internal_alb` was set to `false` and not `create_external_alb`.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
Not necessarily a breaking change but it may introduce an unexpected exposure. To elaborate, if people had `create_external_alb` set to `false`, this change would introduce new security group ingress rules on their internal security group that had not existed previously.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.