### PR TITLE
fix: Windows Build Agent Packer fails to install packages

### DIFF
--- a/assets/packer/build-agents/windows/windows.pkr.hcl
+++ b/assets/packer/build-agents/windows/windows.pkr.hcl
@@ -9,7 +9,7 @@ packer {
 
 variable "region" {
     type = string
-    default = "us-west-2"
+    default = null
 }
 
 variable "vpc_id" {
@@ -24,7 +24,7 @@ variable "subnet_id" {
 
 variable "instance_type" {
   type = string
-  default = "t3.small"
+  default = "m5.large"
 }
 
 variable "associate_public_ip_address" {


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

> Please provide a summary of what's being changed

Changing default instance type and setting `region` value to `null` in `windows.pkr.hcl`. Changed default instance type from `t3.small` to `m5.large`.

Fixes #523 

### User experience

> Please share what the user experience looks like before and after this change

After running `packer install` with `windows.pkr.hcl` in assets/packer/build-agents/windows, the script would fail to install all packages due to a timeout issue. After changing the instance type in `windows.pkr.hcl`, the packer script no longer times out and executes successfully. Also set the default value for `region` to `null` in `windows.pkr.hcl` to ensure the script deploys resources in the default region for the user.
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.