### PR TITLE
Perforce Server module support for FSxN Storage

### DIFF
--- a/assets/packer/perforce/helix-core/p4_configure.sh
+++ b/assets/packer/perforce/helix-core/p4_configure.sh
@@ -329,12 +329,12 @@ print_help() {
     echo "  --plaintext <true/false> Remove the SSL prefix and do not create self signed certificate"
     echo "  --fsxn_password <secret_id> AWS secret manager FSxN fsxadmin user password"
     echo "  --fsxn_svm_name <secret_id> FSxN storage virtual name"
-    echo "  --fsxn_mgmt_ip <ip_address> FSxN managment ip address"
+    echo "  --fsxn_management_ip <ip_address> FSxN managment ip address"
     echo "  --help                   Display this help and exit"
 }
 
 # Parse command-line options
-OPTS=$(getopt -o '' --long p4d_type:,username:,password:,auth:,fqdn:,hx_logs:,hx_metadata:,hx_depots:,case_sensitive:,unicode:,selinux:,plaintext:,fsxn_password:,fsxn_svm_name:,fsxn_mgmt_ip:,help -n 'parse-options' -- "$@")
+OPTS=$(getopt -o '' --long p4d_type:,username:,password:,auth:,fqdn:,hx_logs:,hx_metadata:,hx_depots:,case_sensitive:,unicode:,selinux:,plaintext:,fsxn_password:,fsxn_svm_name:,fsxn_management_ip:,help -n 'parse-options' -- "$@")
 
 if [ $? != 0 ]; then
     log_message "Failed to parse options"
@@ -435,7 +435,7 @@ while true; do
             log_message "FSXN SVM NAME: $FSXN_SVM"
             shift 2
             ;;
-        --fsxn_mgmt_ip)
+        --fsxn_management_ip)
             FSXN_IP="$2"
             log_message "FSXN IP: $FSXN_IP"
             shift 2

--- a/assets/packer/perforce/helix-core/p4_configure.sh
+++ b/assets/packer/perforce/helix-core/p4_configure.sh
@@ -18,7 +18,12 @@ log_message() {
 
 # Function to check if path is an FSx mount point
 is_fsx_mount() {
-    echo "$1" | grep -qE 'fs-[0-9a-f]{17}\.fsx\.[a-z0-9-]+\.amazonaws\.com:/' #to be verified if catches all fsxes
+    echo "$1" | grep -qE '(fs|svm)-[0-9a-f]{17}\.fsx\.[a-z0-9-]+\.amazonaws\.com:/' #to be verified if catches all fsxes
+    return $?
+}
+
+is_iscsi_device() {
+    echo "$1" | grep -qE '^/dev/mapper/'
     return $?
 }
 
@@ -94,6 +99,161 @@ prepare_ebs_volume() {
     mount "$ebs_volume" "$mount_point"
 }
 
+check_command() {
+    if [ $? -ne 0 ]; then
+        log_message "$1 failed. Exiting."
+        exit 1
+    fi
+}
+
+# Function to prepare iSCSI Installation
+prepare_iscsi() {
+    local IGROUP_NAME="perforce"
+    local FLAG_FILE="/var/run/iscsi_prepared.flag"
+    if [ -f "$FLAG_FILE" ]; then
+        echo "iSCSI preparation has already been done. Skipping."
+        return 0
+    fi
+    # Install necessary packages
+    log_message "Installing necessary packages."
+    sudo yum install -y device-mapper-multipath iscsi-initiator-utils sshpass
+    check_command "Package installation"
+
+    # Test connection to ONTAP
+    log_message "Testing connection to ONTAP."
+
+    sshpass -p $FSXN_PASSWORD ssh -o StrictHostKeyChecking=no $ONTAP_USER@$FSXN_IP "version"
+    check_command "Testing connection to ONTAP"
+
+    # Update iSCSI configuration
+    log_message "Updating iSCSI configuration."
+    sudo sed -i 's/node.session.timeo.replacement_timeout = .*/node.session.timeo.replacement_timeout = 5/' /etc/iscsi/iscsid.conf
+    check_command "Updating iSCSI configuration"
+
+    # Start iSCSI service
+    log_message "Starting iSCSI service."
+    sudo service iscsid start
+    check_command "Starting iSCSI service"
+
+    # Enable and start multipath
+    log_message "Enabling and starting multipath."
+    sudo mpathconf --enable --with_multipathd y
+    check_command "Enabling and starting multipath"
+
+    # Get the IQN from the initiatorname.iscsi file
+    INITIATOR_IQN=$(grep -oP 'iqn.\S+' /etc/iscsi/initiatorname.iscsi)
+    log_message "Retrieved initiator IQN: $INITIATOR_IQN"
+
+    log_message "Mapping the IQN to existing igroup"
+    sshpass -p $FSXN_PASSWORD ssh $ONTAP_USER@$FSXN_IP "igroup add -igroup $IGROUP_NAME -vserver $FSXN_SVM -initiator $INITIATOR_IQN"
+    check_command "Mapping LUN to iGroup"
+
+    # Retrieve the iSCSI IP address from ONTAP
+    log_message "Retrieving iSCSI IP address from ONTAP."
+    ISCSI_IP=$(sshpass -p $FSXN_PASSWORD ssh $ONTAP_USER@$FSXN_IP "network interface show -vserver $FSXN_SVM -fields address" | grep iscsi_1 | awk '{print $3}')
+    check_command "Retrieving iSCSI IP address from ONTAP"
+    log_message "Retrieved iSCSI IP address: $ISCSI_IP"
+
+    # Discover the iSCSI target and get the target IQN
+    log_message "Discovering iSCSI target."
+    TARGET_IQN=$(sudo iscsiadm --mode discovery --op update --type sendtargets --portal $ISCSI_IP | grep $ISCSI_IP | awk '{print $2}')
+    check_command "Discovering iSCSI target"
+    log_message "Discovered target IQN: $TARGET_IQN"
+
+    # Log in to the iSCSI target
+    log_message "Logging in to the iSCSI target."
+    sudo iscsiadm --mode node -T $TARGET_IQN --login
+    check_command "Logging in to the iSCSI target"
+
+    log_message "Creating flag file at $FLAG_FILE"
+    sudo touch "$FLAG_FILE"
+
+}
+
+prepare_iscsi_volume() {
+    local VOLUME_NAME=$1
+    local mount_point=$2
+    timeout=90
+    interval=5
+    elapsed=0
+
+
+    # Set VOLUME based on volume path
+    if [[ "$VOLUME_NAME" == *"log"* ]]; then
+        VOLUME="logs"
+    elif [[ "$VOLUME_NAME" == *"metadata"* ]]; then
+        VOLUME="metadata"
+    else
+        VOLUME="depot"
+    fi
+
+    # Check if iSCSI preparation is needed
+    prepare_iscsi
+
+    local fs_type=$(lsblk -no FSTYPE "$VOLUME_NAME")
+    if [ -z "$fs_type" ]; then
+        # Retrieve the serial-hex value from the LUN
+        log_message "Retrieving serial-hex value from the LUN."
+        SERIAL_HEX=$(sshpass -p $FSXN_PASSWORD ssh $ONTAP_USER@$FSXN_IP "lun show -vserver $FSXN_SVM -path /vol/$VOLUME/$VOLUME -fields serial-hex" | grep /vol/$VOLUME/$VOLUME | awk '{print $3}')
+        check_command "Retrieving serial-hex value from the LUN"
+        log_message "Retrieved serial-hex value: $SERIAL_HEX"
+
+        # Check if serial-hex is empty
+        if [ -z "$SERIAL_HEX" ]; then
+            log_message "Serial-hex value is empty. Exiting."
+            exit 1
+        fi
+
+        # Rescan iSCSI sessions to detect new LUNs
+        log_message "Rescanning iSCSI sessions."
+        sudo iscsiadm -m session --rescan
+        check_command "Rescanning iSCSI sessions"
+
+        # Configure multipath
+        log_message "Configuring multipath."
+        CONF=/etc/multipath.conf
+        grep -q '^multipaths {' $CONF
+        UNCOMMENTED=$?
+        if [ $UNCOMMENTED -eq 0 ]
+        then
+                sed -i '/^multipaths {/a\\tmultipath {\n\t\twwid 3600a0980'"${SERIAL_HEX}"'\n\t\talias '"${VOLUME}"'\n\t}\n' $CONF
+        else
+                printf "multipaths {\n\tmultipath {\n\t\twwid 3600a0980$SERIAL_HEX\n\t\talias $VOLUME\n\t}\n}" >> $CONF
+        fi
+        check_command "Configuring multipath"
+
+        # Restart multipathd service
+        log_message "Restarting multipathd service."
+        sudo systemctl restart multipathd.service
+        check_command "Restarting multipathd service"
+
+        log_message "Checking if the new partition exists."
+        while [ $elapsed -lt $timeout ]; do
+        if [ -e $VOLUME_NAME ]; then
+        log_message "The device $VOLUME_NAME exists."
+        break
+        fi
+        sleep $interval
+        elapsed=$((elapsed + interval))
+        done
+        if [ ! -e $VOLUME_NAME ]; then
+        log_message "The device $VOLUME_NAME does not exist. Exiting."
+        exit 1
+        fi
+            log_message "Creating the file system on the new partition."
+            sudo mkfs.ext4 $VOLUME_NAME
+            check_command "Creating the file system on the new partition"
+    fi
+
+    # Mount the iSCSI disk
+    log_message "Mounting the iSCSI disk."
+    sudo mount $VOLUME_NAME $mount_point
+    check_command "Mounting the iSCSI disk"
+
+    log_message "iSCSI setup script completed for ${VOLUME_NAME}"
+
+}
+
 # Function to copy SiteTags template and update with AWS regions -> This file will be updated by Ansible with replica AWS regions.
 prepare_site_tags() {
   log_message "Setting up SiteTags for installation"
@@ -165,11 +325,14 @@ print_help() {
     echo "  --unicode <true/false>   Set the Helix Core Server with -xi flag for Unicode"
     echo "  --selinux <true/false>   Update labels for SELinux"
     echo "  --plaintext <true/false> Remove the SSL prefix and do not create self signed certificate"
+    echo "  --fsxn_password <secret_id> AWS secret manager FSxN fsxadmin user password"
+    echo "  --fsxn_svm_name <secret_id> FSxN storage virtual name"
+    echo "  --fsxn_ip_mgmt <ip_address> FSxN managment ip address"
     echo "  --help                   Display this help and exit"
 }
 
 # Parse command-line options
-OPTS=$(getopt -o '' --long p4d_type:,username:,password:,auth:,fqdn:,hx_logs:,hx_metadata:,hx_depots:,case_sensitive:,unicode:,selinux:,plaintext:,help -n 'parse-options' -- "$@")
+OPTS=$(getopt -o '' --long p4d_type:,username:,password:,auth:,fqdn:,hx_logs:,hx_metadata:,hx_depots:,case_sensitive:,unicode:,selinux:,plaintext:,fsxn_password:,fsxn_svm_name:,fsxn_ip_mgmt:,help -n 'parse-options' -- "$@")
 
 if [ $? != 0 ]; then
     log_message "Failed to parse options"
@@ -177,6 +340,8 @@ if [ $? != 0 ]; then
 fi
 
 eval set -- "$OPTS"
+
+
 
 while true; do
     case "$1" in
@@ -259,6 +424,20 @@ while true; do
                 exit 1
             fi
             ;;
+        --fsxn_password)
+            FSXN_PASS="$2"
+            shift 2
+            ;;
+        --fsxn_svm_name)
+            FSXN_SVM="$2"
+            log_message "FSXN SVM NAME: $FSXN_SVM"
+            shift 2
+            ;;
+        --fsxn_ip_mgmt)
+            FSXN_IP="$2"
+            log_message "FSXN IP: $FSXN_IP"
+            shift 2
+            ;;
         --help)
             print_help
             exit 0
@@ -284,6 +463,8 @@ fi
 # Fetch credentials for admin user from secrets manager
 P4D_ADMIN_USERNAME=$(resolve_aws_secret $P4D_ADMIN_USERNAME_SECRET_ID)
 P4D_ADMIN_PASS=$(resolve_aws_secret $P4D_ADMIN_PASS_SECRET_ID)
+FSXN_PASSWORD=$(resolve_aws_secret $FSXN_PASS)
+ONTAP_USER="fsxadmin"
 
 # Function to perform operations
 perform_operations() {
@@ -295,16 +476,22 @@ perform_operations() {
         local dest_dir=$2
         local mount_options=""
         local fs_type=""
-
         if is_fsx_mount "$mount_point"; then
             # Mount as FSx
+            log_message "nfs device detected: $mount_point"
             mount -t nfs -o nconnect=16,rsize=1048576,wsize=1048576,timeo=600 "$mount_point" "$dest_dir"
             mount_options="nfs nconnect=16,rsize=1048576,wsize=1048576,timeo=600"
             fs_type="nfs"
+        elif is_iscsi_device "$mount_point"; then
+            # Handle iSCSI device
+            log_message "iSCSI device detected: $mount_point"
+            prepare_iscsi_volume "$mount_point" "$dest_dir"
+            mount_options="defaults,_netdev"
+            fs_type="ext4"
         else
             # Mount as EBS the called function also creates XFS on EBS
+            log_message "ebs device detected: $mount_point"
             prepare_ebs_volume "$mount_point" "$dest_dir"
-
             mount_options="defaults"
             fs_type="xfs"
 
@@ -321,6 +508,11 @@ perform_operations() {
     mount_fs_or_ebs $EBS_LOGS /mnt/temp_hxlogs
     mount_fs_or_ebs $EBS_METADATA /mnt/temp_hxmetadata
     mount_fs_or_ebs $EBS_DEPOTS /mnt/temp_hxdepots
+
+    # Create temporary directories and mount
+    mkdir -p /hxlogs
+    mkdir -p /hxmetadata
+    mkdir -p /hxdepots
 
     # Syncing directories
     rsync -av /hxlogs/ /mnt/temp_hxlogs/
@@ -357,9 +549,9 @@ condition_met=false
 
 while [ $attempt -le $MAX_ATTEMPTS ] && [ "$condition_met" = false ]; do
     # Check if EBS volumes or FSx mount points are provided for all required paths
-    if ( [ -e "$EBS_LOGS" ] || is_fsx_mount "$EBS_LOGS" ) && \
-       ( [ -e "$EBS_METADATA" ] || is_fsx_mount "$EBS_METADATA" ) && \
-       ( [ -e "$EBS_DEPOTS" ] || is_fsx_mount "$EBS_DEPOTS" ); then
+    if ( [ -e "$EBS_LOGS" ] || is_fsx_mount "$EBS_LOGS" || is_iscsi_device "$EBS_LOGS") && \
+       ( [ -e "$EBS_METADATA" ] || is_fsx_mount "$EBS_METADATA" || is_iscsi_device "$EBS_METADATA" ) && \
+       ( [ -e "$EBS_DEPOTS" ] || is_fsx_mount "$EBS_DEPOTS" || is_iscsi_device "$EBS_DEPOTS"); then
         condition_met=true
         perform_operations
     else

--- a/assets/packer/perforce/helix-core/p4_configure.sh
+++ b/assets/packer/perforce/helix-core/p4_configure.sh
@@ -376,17 +376,17 @@ while true; do
             ;;
         --hx_logs)
             EBS_LOGS="$2"
-            log_message "EBS_LOGS: $EBS_LOGS"
+            log_message "LOGS: $EBS_LOGS"
             shift 2
             ;;
         --hx_metadata)
             EBS_METADATA="$2"
-            log_message "EBS_METADATA: $EBS_METADATA"
+            log_message "METADATA: $EBS_METADATA"
             shift 2
             ;;
         --hx_depots)
             EBS_DEPOTS="$2"
-            log_message "EBS_DEPOTS: $EBS_DEPOTS"
+            log_message "DEPOTS: $EBS_DEPOTS"
             shift 2
             ;;
         --case_sensitive)

--- a/modules/perforce/examples/fsxn/data.tf
+++ b/modules/perforce/examples/fsxn/data.tf
@@ -1,0 +1,1 @@
+data "aws_region" "current" {}

--- a/modules/perforce/examples/fsxn/dns.tf
+++ b/modules/perforce/examples/fsxn/dns.tf
@@ -1,0 +1,16 @@
+##########################################
+# Route53 Hosted Zone for FQDN
+##########################################
+data "aws_route53_zone" "root" {
+  name         = var.root_domain_name
+  private_zone = false
+}
+
+# Route all external Helix Core traffic to P4 Server
+resource "aws_route53_record" "external_helix_core" {
+  #checkov:skip=CKV2_AWS_23: Route53 Record associated with P4 Server EIP
+  zone_id = data.aws_route53_zone.root.zone_id
+  name    = "perforce.${data.aws_route53_zone.root.name}"
+  type    = "A"
+  records = [module.perforce_helix_core.helix_core_eip_public_ip]
+}

--- a/modules/perforce/examples/fsxn/dns.tf
+++ b/modules/perforce/examples/fsxn/dns.tf
@@ -12,5 +12,6 @@ resource "aws_route53_record" "external_helix_core" {
   zone_id = data.aws_route53_zone.root.zone_id
   name    = "perforce.${data.aws_route53_zone.root.name}"
   type    = "A"
+  ttl     = 300
   records = [module.perforce_helix_core.helix_core_eip_public_ip]
 }

--- a/modules/perforce/examples/fsxn/local.tf
+++ b/modules/perforce/examples/fsxn/local.tf
@@ -1,0 +1,13 @@
+data "aws_availability_zones" "available" {}
+
+locals {
+  # VPC Configuration
+  vpc_cidr_block       = "10.0.0.0/16"
+  public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
+  private_subnet_cidrs = ["10.0.3.0/24", "10.0.4.0/24"]
+
+  tags = {
+    environment = "cgd"
+  }
+  azs = slice(data.aws_availability_zones.available.names, 0, 2)
+}

--- a/modules/perforce/examples/fsxn/main.tf
+++ b/modules/perforce/examples/fsxn/main.tf
@@ -73,6 +73,7 @@ module "perforce_helix_core" {
   fsxn_mgmt_ip                      = aws_fsx_ontap_file_system.helix_core_fs.endpoints[0].management[0].dns_name
   fsxn_svm_name                     = aws_fsx_ontap_storage_virtual_machine.helix_core_svm.name
   amazon_fsxn_svm_id                = aws_fsx_ontap_storage_virtual_machine.helix_core_svm.id
+  amazon_fsxn_filesystem_id         = aws_fsx_ontap_file_system.helix_core_fs.id
   fsxn_filesystem_security_group_id = aws_security_group.fsx_ontap_file_system_sg.id
 
 

--- a/modules/perforce/examples/fsxn/main.tf
+++ b/modules/perforce/examples/fsxn/main.tf
@@ -12,15 +12,17 @@ resource "aws_security_group" "fsx_ontap_file_system_sg" {
   }
 }
 
-# TODO: Restrict Security groups to allow access only from Helix Core server.
-resource "aws_vpc_security_group_ingress_rule" "fsxn_ibound_helix_core_link" {
-  ip_protocol       = "-1"
-  description       = "Allows all inbound access from the VPC."
-  security_group_id = aws_security_group.fsx_ontap_file_system_sg.id
-  cidr_ipv4         = aws_vpc.perforce_vpc.cidr_block
+resource "aws_vpc_security_group_ingress_rule" "fsxn_inbound_helix_core" {
+  ip_protocol                  = "-1"
+  description                  = "Allows all inbound access from the VPC."
+  security_group_id            = aws_security_group.fsx_ontap_file_system_sg.id
+  referenced_security_group_id = module.perforce_helix_core.security_group_id
   lifecycle {
     create_before_destroy = true
   }
+  depends_on = [
+    module.perforce_helix_core
+  ]
 }
 
 resource "aws_fsx_ontap_file_system" "helix_core_fs" {
@@ -75,7 +77,6 @@ module "perforce_helix_core" {
   amazon_fsxn_svm_id                = aws_fsx_ontap_storage_virtual_machine.helix_core_svm.id
   amazon_fsxn_filesystem_id         = aws_fsx_ontap_file_system.helix_core_fs.id
   fsxn_filesystem_security_group_id = aws_security_group.fsx_ontap_file_system_sg.id
-
 
   # Configuration
   server_type = "p4d_commit"

--- a/modules/perforce/examples/fsxn/main.tf
+++ b/modules/perforce/examples/fsxn/main.tf
@@ -72,7 +72,7 @@ module "perforce_helix_core" {
   # FSxN configuration - FSxN ISCSI
   fsxn_aws_profile                  = var.fsxn_aws_profile
   fsxn_password                     = awscc_secretsmanager_secret.fsxn_user_password.secret_id
-  fsxn_mgmt_ip                      = aws_fsx_ontap_file_system.helix_core_fs.endpoints[0].management[0].dns_name
+  fsxn_management_ip                = aws_fsx_ontap_file_system.helix_core_fs.endpoints[0].management[0].dns_name
   fsxn_svm_name                     = aws_fsx_ontap_storage_virtual_machine.helix_core_svm.name
   amazon_fsxn_svm_id                = aws_fsx_ontap_storage_virtual_machine.helix_core_svm.id
   amazon_fsxn_filesystem_id         = aws_fsx_ontap_file_system.helix_core_fs.id

--- a/modules/perforce/examples/fsxn/main.tf
+++ b/modules/perforce/examples/fsxn/main.tf
@@ -1,0 +1,81 @@
+##########################################
+# FSx ONTAP File System
+##########################################
+
+resource "aws_security_group" "fsx_ontap_file_system_sg" {
+  #checkov:skip=CKV2_AWS_5: False positive, this SG is used by the FSX service
+  name        = "perforce-fsxn-file-system"
+  description = "Perforce FSxN File System"
+  vpc_id      = aws_vpc.perforce_vpc.id
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# TODO: Restrict Security groups to allow access only from Helix Core server.
+resource "aws_vpc_security_group_ingress_rule" "fsxn_ibound_helix_core_link" {
+  ip_protocol       = "-1"
+  description       = "Allows all inbound access from the VPC."
+  security_group_id = aws_security_group.fsx_ontap_file_system_sg.id
+  cidr_ipv4         = aws_vpc.perforce_vpc.cidr_block
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_fsx_ontap_file_system" "helix_core_fs" {
+  #checkov:skip=CKV_AWS_178: CMK is out of scope.
+  storage_capacity    = 1024
+  subnet_ids          = [aws_subnet.private_subnets[0].id]
+  preferred_subnet_id = aws_subnet.private_subnets[0].id
+  deployment_type     = "SINGLE_AZ_1"
+  throughput_capacity = 128
+  fsx_admin_password  = var.fsxn_password
+  security_group_ids  = [aws_security_group.fsx_ontap_file_system_sg.id]
+}
+
+resource "aws_fsx_ontap_storage_virtual_machine" "helix_core_svm" {
+  file_system_id = aws_fsx_ontap_file_system.helix_core_fs.id
+  name           = "helix_core_svm"
+}
+
+resource "awscc_secretsmanager_secret" "fsxn_user_password" {
+  name          = "perforceFSxnUserPassword"
+  secret_string = var.fsxn_password
+}
+
+##########################################
+# Perforce Helix Core
+##########################################
+
+module "perforce_helix_core" {
+  source = "../../helix-core"
+
+  # Networking
+  vpc_id                      = aws_vpc.perforce_vpc.id
+  instance_subnet_id          = aws_subnet.private_subnets[0].id
+  internal                    = false
+  fully_qualified_domain_name = "core.helix.perforce.${var.root_domain_name}"
+
+  # Compute and Storage
+  instance_type         = "c8g.large"
+  instance_architecture = "arm64"
+  storage_type          = "FSxN"
+  depot_volume_size     = 64
+  metadata_volume_size  = 32
+  logs_volume_size      = 32
+  fsxn_region           = data.aws_region.current.name
+  protocol              = "ISCSI"
+
+  # FSxN configuration - FSxN ISCSI
+  fsxn_aws_profile                  = var.fsxn_aws_profile
+  fsxn_password                     = awscc_secretsmanager_secret.fsxn_user_password.secret_id
+  fsxn_mgmt_ip                      = aws_fsx_ontap_file_system.helix_core_fs.endpoints[0].management[0].dns_name
+  fsxn_svm_name                     = aws_fsx_ontap_storage_virtual_machine.helix_core_svm.name
+  amazon_fsxn_svm_id                = aws_fsx_ontap_storage_virtual_machine.helix_core_svm.id
+  fsxn_filesystem_security_group_id = aws_security_group.fsx_ontap_file_system_sg.id
+
+
+  # Configuration
+  server_type = "p4d_commit"
+}

--- a/modules/perforce/examples/fsxn/outputs.tf
+++ b/modules/perforce/examples/fsxn/outputs.tf
@@ -1,0 +1,9 @@
+output "amazon_fsxn_filesystem" {
+  value       = aws_fsx_ontap_file_system.helix_core_fs.id
+  description = "FSxN filesystem ID"
+}
+
+output "helix_core_connection_string" {
+  value       = "ssl:perforce.${var.root_domain_name}:1666"
+  description = "The connection string for the Helix Core server. Set your P4PORT environment variable to this value."
+}

--- a/modules/perforce/examples/fsxn/variables.tf
+++ b/modules/perforce/examples/fsxn/variables.tf
@@ -1,0 +1,14 @@
+variable "root_domain_name" {
+  type        = string
+  description = "The root domain name you would like to use for DNS."
+}
+
+variable "fsxn_password" {
+  description = "FSxN admin user password AWS secret manager arn"
+  type        = string
+}
+
+variable "fsxn_aws_profile" {
+  description = "AWS profile for managing FSxN"
+  type        = string
+}

--- a/modules/perforce/examples/fsxn/versions.tf
+++ b/modules/perforce/examples/fsxn/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.89.0"
+    }
+    awscc = {
+      source  = "hashicorp/awscc"
+      version = "1.34.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.7.1"
+    }
+    netapp-ontap = {
+      source  = "NetApp/netapp-ontap"
+      version = "2.1.1"
+    }
+  }
+}

--- a/modules/perforce/examples/fsxn/vpc.tf
+++ b/modules/perforce/examples/fsxn/vpc.tf
@@ -1,0 +1,131 @@
+##########################################
+# VPC
+##########################################
+
+resource "aws_vpc" "perforce_vpc" {
+  cidr_block = local.vpc_cidr_block
+  tags = merge(local.tags,
+    {
+      Name = "perforce-vpc"
+    }
+  )
+  enable_dns_hostnames = true
+  #checkov:skip=CKV2_AWS_11: VPC flow logging disabled by design
+}
+
+# Set default SG to restrict all traffic
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.perforce_vpc.id
+}
+
+##########################################
+# Subnets
+##########################################
+
+resource "aws_subnet" "public_subnets" {
+  count             = length(local.public_subnet_cidrs)
+  vpc_id            = aws_vpc.perforce_vpc.id
+  cidr_block        = element(local.public_subnet_cidrs, count.index)
+  availability_zone = element(local.azs, count.index)
+
+  tags = merge(local.tags,
+    {
+      Name = "pub-subnet-${count.index + 1}"
+    }
+  )
+}
+
+resource "aws_subnet" "private_subnets" {
+  count             = length(local.private_subnet_cidrs)
+  vpc_id            = aws_vpc.perforce_vpc.id
+  cidr_block        = element(local.private_subnet_cidrs, count.index)
+  availability_zone = element(local.azs, count.index)
+
+  tags = merge(local.tags,
+    {
+      Name = "pvt-subnet-${count.index + 1}"
+    }
+  )
+}
+
+##########################################
+# Internet Gateway
+##########################################
+
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.perforce_vpc.id
+  tags = merge(local.tags,
+    {
+      Name = "perforce-igw"
+    }
+  )
+}
+
+##########################################
+# Route Tables & NAT Gateway
+##########################################
+
+resource "aws_route_table" "public_rt" {
+  vpc_id = aws_vpc.perforce_vpc.id
+
+  # public route to the internet
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = merge(local.tags,
+    {
+      Name = "perforce-public-rt"
+    }
+  )
+}
+
+resource "aws_route_table_association" "public_rt_asso" {
+  count          = length(aws_subnet.public_subnets)
+  route_table_id = aws_route_table.public_rt.id
+  subnet_id      = aws_subnet.public_subnets[count.index].id
+}
+
+resource "aws_eip" "nat_gateway_eip" {
+  depends_on = [aws_internet_gateway.igw]
+  #checkov:skip=CKV2_AWS_19:EIP associated with NAT Gateway through association ID
+  tags = merge(local.tags,
+    {
+      Name = "perforce-nat-eip"
+    }
+  )
+}
+
+resource "aws_route_table" "private_rt" {
+  vpc_id = aws_vpc.perforce_vpc.id
+
+  tags = merge(local.tags,
+    {
+      Name = "perforce-private-rt"
+    }
+  )
+}
+
+# route to the internet through NAT gateway
+resource "aws_route" "private_rt_nat_gateway" {
+  route_table_id         = aws_route_table.private_rt.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.nat_gateway.id
+}
+
+resource "aws_route_table_association" "private_rt_asso" {
+  count          = length(aws_subnet.private_subnets)
+  route_table_id = aws_route_table.private_rt.id
+  subnet_id      = aws_subnet.private_subnets[count.index].id
+}
+
+resource "aws_nat_gateway" "nat_gateway" {
+  allocation_id = aws_eip.nat_gateway_eip.id
+  subnet_id     = aws_subnet.public_subnets[0].id
+  tags = merge(local.tags,
+    {
+      Name = "perforce-nat"
+    }
+  )
+}

--- a/modules/perforce/helix-core/README.md
+++ b/modules/perforce/helix-core/README.md
@@ -51,8 +51,9 @@ No modules.
 | [aws_volume_attachment.depot_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/volume_attachment) | resource |
 | [aws_volume_attachment.logs_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/volume_attachment) | resource |
 | [aws_volume_attachment.metadata_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/volume_attachment) | resource |
-| [aws_vpc_security_group_egress_rule.fsxn_lambda_link_security_group_egress_rule](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.helix_core_internet](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.link_outbound_fsxn](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.fsxn_inbound_link](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [awscc_secretsmanager_secret.helix_core_super_user_password](https://registry.terraform.io/providers/hashicorp/awscc/1.34.0/docs/resources/secretsmanager_secret) | resource |
 | [awscc_secretsmanager_secret.helix_core_super_user_username](https://registry.terraform.io/providers/hashicorp/awscc/1.34.0/docs/resources/secretsmanager_secret) | resource |
 | [netapp-ontap_lun.depots_volume_lun](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/lun) | resource |

--- a/modules/perforce/helix-core/README.md
+++ b/modules/perforce/helix-core/README.md
@@ -17,7 +17,7 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.89.0 |
 | <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 1.34.0 |
-| <a name="provider_netapp-ontap"></a> [netapp-ontap](#provider\_netapp-ontap) | 2.0.0 |
+| <a name="provider_netapp-ontap"></a> [netapp-ontap](#provider\_netapp-ontap) | 2.1.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.1 |
 
 ## Modules
@@ -41,6 +41,9 @@ No modules.
 | [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.helix_core_default_role_helix_core_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.helix_core_default_role_ssm_managed_instance_core](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_service_basic_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_service_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.lambda_vpc_access_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.helix_core_instance](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/instance) | resource |
 | [aws_lambda_function.lambda_function](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lambda_function) | resource |
 | [aws_security_group.fsxn_lambda_link_security_group](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
@@ -55,10 +58,10 @@ No modules.
 | [netapp-ontap_lun.depots_volume_lun](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/lun) | resource |
 | [netapp-ontap_lun.logs_volume_lun](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/lun) | resource |
 | [netapp-ontap_lun.metadata_volume_lun](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/lun) | resource |
-| [netapp-ontap_protocols_san_igroup_resource.perforce_igroup](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/protocols_san_igroup_resource) | resource |
-| [netapp-ontap_protocols_san_lun-maps_resource.depots_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/protocols_san_lun-maps_resource) | resource |
-| [netapp-ontap_protocols_san_lun-maps_resource.logs_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/protocols_san_lun-maps_resource) | resource |
-| [netapp-ontap_protocols_san_lun-maps_resource.metadata_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/protocols_san_lun-maps_resource) | resource |
+| [netapp-ontap_san_igroup.perforce_igroup](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/san_igroup) | resource |
+| [netapp-ontap_san_lun-map.depots_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/san_lun-map) | resource |
+| [netapp-ontap_san_lun-map.logs_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/san_lun-map) | resource |
+| [netapp-ontap_san_lun-map.metadata_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/san_lun-map) | resource |
 | [random_string.helix_core](https://registry.terraform.io/providers/hashicorp/random/3.7.1/docs/resources/string) | resource |
 | [aws_ami.helix_core_ami](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.ec2_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |

--- a/modules/perforce/helix-core/README.md
+++ b/modules/perforce/helix-core/README.md
@@ -8,6 +8,7 @@
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.89.0 |
 | <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | 1.34.0 |
+| <a name="requirement_netapp-ontap"></a> [netapp-ontap](#requirement\_netapp-ontap) | 2.1.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | 3.7.1 |
 
 ## Providers
@@ -16,6 +17,7 @@
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.89.0 |
 | <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 1.34.0 |
+| <a name="provider_netapp-ontap"></a> [netapp-ontap](#provider\_netapp-ontap) | 2.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.1 |
 
 ## Modules
@@ -30,35 +32,60 @@ No modules.
 | [aws_ebs_volume.logs](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ebs_volume) | resource |
 | [aws_ebs_volume.metadata](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ebs_volume) | resource |
 | [aws_eip.helix_core_eip](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/eip) | resource |
+| [aws_fsx_ontap_volume.depot](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/fsx_ontap_volume) | resource |
+| [aws_fsx_ontap_volume.logs](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/fsx_ontap_volume) | resource |
+| [aws_fsx_ontap_volume.metadata](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/fsx_ontap_volume) | resource |
 | [aws_iam_instance_profile.helix_core_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.helix_core_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_policy) | resource |
 | [aws_iam_role.helix_core_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.helix_core_default_role_helix_core_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.helix_core_default_role_ssm_managed_instance_core](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_instance.helix_core_instance](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/instance) | resource |
+| [aws_lambda_function.lambda_function](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lambda_function) | resource |
+| [aws_security_group.fsxn_lambda_link_security_group](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
 | [aws_security_group.helix_core_security_group](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
 | [aws_volume_attachment.depot_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/volume_attachment) | resource |
 | [aws_volume_attachment.logs_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/volume_attachment) | resource |
 | [aws_volume_attachment.metadata_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/volume_attachment) | resource |
+| [aws_vpc_security_group_egress_rule.fsxn_lambda_link_security_group_egress_rule](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_egress_rule.helix_core_internet](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
 | [awscc_secretsmanager_secret.helix_core_super_user_password](https://registry.terraform.io/providers/hashicorp/awscc/1.34.0/docs/resources/secretsmanager_secret) | resource |
 | [awscc_secretsmanager_secret.helix_core_super_user_username](https://registry.terraform.io/providers/hashicorp/awscc/1.34.0/docs/resources/secretsmanager_secret) | resource |
+| [netapp-ontap_lun.depots_volume_lun](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/lun) | resource |
+| [netapp-ontap_lun.logs_volume_lun](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/lun) | resource |
+| [netapp-ontap_lun.metadata_volume_lun](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/lun) | resource |
+| [netapp-ontap_protocols_san_igroup_resource.perforce_igroup](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/protocols_san_igroup_resource) | resource |
+| [netapp-ontap_protocols_san_lun-maps_resource.depots_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/protocols_san_lun-maps_resource) | resource |
+| [netapp-ontap_protocols_san_lun-maps_resource.logs_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/protocols_san_lun-maps_resource) | resource |
+| [netapp-ontap_protocols_san_lun-maps_resource.metadata_lun_map](https://registry.terraform.io/providers/NetApp/netapp-ontap/2.1.1/docs/resources/protocols_san_lun-maps_resource) | resource |
 | [random_string.helix_core](https://registry.terraform.io/providers/hashicorp/random/3.7.1/docs/resources/string) | resource |
 | [aws_ami.helix_core_ami](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/ami) | data source |
 | [aws_iam_policy_document.ec2_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.helix_core_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/region) | data source |
+| [aws_secretsmanager_secret.fsxn_password](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/secretsmanager_secret) | data source |
+| [aws_secretsmanager_secret_version.fsxn_password](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_subnet.instance_subnet](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/subnet) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_amazon_fsxn_filesystem_id"></a> [amazon\_fsxn\_filesystem\_id](#input\_amazon\_fsxn\_filesystem\_id) | The ID of the existing FSx ONTAP file system to use if storage type is FSxN. | `string` | `""` | no |
+| <a name="input_amazon_fsxn_svm_id"></a> [amazon\_fsxn\_svm\_id](#input\_amazon\_fsxn\_svm\_id) | The ID of the Storage Virtual Machine (SVM) for the FSx ONTAP filesystem. | `string` | `""` | no |
 | <a name="input_create_default_sg"></a> [create\_default\_sg](#input\_create\_default\_sg) | Whether to create a default security group for the Helix Core instance. | `bool` | `true` | no |
 | <a name="input_create_helix_core_default_role"></a> [create\_helix\_core\_default\_role](#input\_create\_helix\_core\_default\_role) | Optional creation of Helix Core default IAM Role with SSM managed instance core policy attached. Default is set to true. | `bool` | `true` | no |
 | <a name="input_custom_helix_core_role"></a> [custom\_helix\_core\_role](#input\_custom\_helix\_core\_role) | ARN of the custom IAM Role you wish to use with Helix Core. | `string` | `null` | no |
 | <a name="input_depot_volume_size"></a> [depot\_volume\_size](#input\_depot\_volume\_size) | The size of the depot volume in GiB. Defaults to 128 GiB. | `number` | `128` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The current environment (e.g. dev, prod, etc.) | `string` | `"dev"` | no |
 | <a name="input_existing_security_groups"></a> [existing\_security\_groups](#input\_existing\_security\_groups) | A list of existing security group IDs to attach to the Helix Core load balancer. | `list(string)` | `[]` | no |
+| <a name="input_fsxn_aws_profile"></a> [fsxn\_aws\_profile](#input\_fsxn\_aws\_profile) | FSxN admin user password AWS secret manager arn | `string` | `""` | no |
+| <a name="input_fsxn_filesystem_security_group_id"></a> [fsxn\_filesystem\_security\_group\_id](#input\_fsxn\_filesystem\_security\_group\_id) | The ID of the security group for the FSxN file system. | `string` | `null` | no |
+| <a name="input_fsxn_mgmt_ip"></a> [fsxn\_mgmt\_ip](#input\_fsxn\_mgmt\_ip) | FSxN management ip address | `string` | `""` | no |
+| <a name="input_fsxn_password"></a> [fsxn\_password](#input\_fsxn\_password) | FSxN admin user password AWS secret manager arn | `string` | `""` | no |
+| <a name="input_fsxn_region"></a> [fsxn\_region](#input\_fsxn\_region) | The ID of the Storage Virtual Machine (SVM) for the FSx ONTAP filesystem. | `string` | `"us-west-2"` | no |
+| <a name="input_fsxn_svm_name"></a> [fsxn\_svm\_name](#input\_fsxn\_svm\_name) | FSxN storage virtual machine name | `string` | `"fsx"` | no |
 | <a name="input_fully_qualified_domain_name"></a> [fully\_qualified\_domain\_name](#input\_fully\_qualified\_domain\_name) | The fully qualified domain name where Helix Core will be available. This is used to generate self-signed certificates on the Helix Core server. | `string` | `null` | no |
 | <a name="input_helix_authentication_service_url"></a> [helix\_authentication\_service\_url](#input\_helix\_authentication\_service\_url) | The URL for the Helix Authentication Service. | `string` | `null` | no |
 | <a name="input_helix_case_sensitive"></a> [helix\_case\_sensitive](#input\_helix\_case\_sensitive) | Whether or not the server should be case insensitive (Server will run '-C1' mode), or if the server will run with case sensitivity default of the underlying platform. False enables '-C1' mode | `bool` | `true` | no |
@@ -73,9 +100,10 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name attached to swarm module resources. | `string` | `"helix-core"` | no |
 | <a name="input_plaintext"></a> [plaintext](#input\_plaintext) | Whether to enable plaintext authentication for Helix Core. This is not recommended for production environments unless you are using a load balancer for TLS termination. | `bool` | `false` | no |
 | <a name="input_project_prefix"></a> [project\_prefix](#input\_project\_prefix) | The project prefix for this workload. This is appended to the beginning of most resource names. | `string` | `"cgd"` | no |
+| <a name="input_protocol"></a> [protocol](#input\_protocol) | Specify the protocol (NFS or ISCSI) | `string` | `""` | no |
 | <a name="input_selinux"></a> [selinux](#input\_selinux) | Whether to apply SELinux label updates for Helix Core. Don't enable this if SELinux is disabled on your target operating system. | `bool` | `false` | no |
 | <a name="input_server_type"></a> [server\_type](#input\_server\_type) | The Perforce Helix Core server type. | `string` | n/a | yes |
-| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | The type of backing store [EBS, FSxZ] | `string` | n/a | yes |
+| <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | The type of backing store [EBS, FSxZ, FSxN] | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br>  "iac-management": "CGD-Toolkit",<br>  "iac-module": "helix-core",<br>  "iac-provider": "Terraform"<br>}</pre> | no |
 | <a name="input_unicode"></a> [unicode](#input\_unicode) | Whether to enable Unicode configuration for Helix Core the -xi flag for p4d. Set to true to enable Unicode support. | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC where Helix Core should be deployed | `string` | n/a | yes |
@@ -84,6 +112,7 @@ No modules.
 
 | Name | Description |
 |------|-------------|
+| <a name="output_fsxn_link_security_group_id"></a> [fsxn\_link\_security\_group\_id](#output\_fsxn\_link\_security\_group\_id) | The ID of the security group for the FSxN Link Lambda. |
 | <a name="output_helix_core_eip_id"></a> [helix\_core\_eip\_id](#output\_helix\_core\_eip\_id) | The ID of the Elastic IP associated with your Helix Core instance. |
 | <a name="output_helix_core_eip_public_ip"></a> [helix\_core\_eip\_public\_ip](#output\_helix\_core\_eip\_public\_ip) | The public IP of your Helix Core instance. |
 | <a name="output_helix_core_instance_id"></a> [helix\_core\_instance\_id](#output\_helix\_core\_instance\_id) | Instance ID for the Helix Core instance |

--- a/modules/perforce/helix-core/README.md
+++ b/modules/perforce/helix-core/README.md
@@ -86,7 +86,7 @@ No modules.
 | <a name="input_existing_security_groups"></a> [existing\_security\_groups](#input\_existing\_security\_groups) | A list of existing security group IDs to attach to the Helix Core load balancer. | `list(string)` | `[]` | no |
 | <a name="input_fsxn_aws_profile"></a> [fsxn\_aws\_profile](#input\_fsxn\_aws\_profile) | FSxN admin user password AWS secret manager arn | `string` | `""` | no |
 | <a name="input_fsxn_filesystem_security_group_id"></a> [fsxn\_filesystem\_security\_group\_id](#input\_fsxn\_filesystem\_security\_group\_id) | The ID of the security group for the FSxN file system. | `string` | `null` | no |
-| <a name="input_fsxn_mgmt_ip"></a> [fsxn\_mgmt\_ip](#input\_fsxn\_mgmt\_ip) | FSxN management ip address | `string` | `""` | no |
+| <a name="input_fsxn_management_ip"></a> [fsxn\_management\_ip](#input\_fsxn\_management\_ip) | FSxN management ip address | `string` | `""` | no |
 | <a name="input_fsxn_password"></a> [fsxn\_password](#input\_fsxn\_password) | FSxN admin user password AWS secret manager arn | `string` | `""` | no |
 | <a name="input_fsxn_region"></a> [fsxn\_region](#input\_fsxn\_region) | The ID of the Storage Virtual Machine (SVM) for the FSx ONTAP filesystem. | `string` | `"us-west-2"` | no |
 | <a name="input_fsxn_svm_name"></a> [fsxn\_svm\_name](#input\_fsxn\_svm\_name) | FSxN storage virtual machine name | `string` | `"fsx"` | no |

--- a/modules/perforce/helix-core/data.tf
+++ b/modules/perforce/helix-core/data.tf
@@ -2,6 +2,8 @@ data "aws_subnet" "instance_subnet" {
   id = var.instance_subnet_id
 }
 
+data "aws_region" "current" {}
+
 # Fetching custom Perforce Helix Core AMI
 data "aws_ami" "helix_core_ami" {
   most_recent = true

--- a/modules/perforce/helix-core/fsxn.tf
+++ b/modules/perforce/helix-core/fsxn.tf
@@ -11,7 +11,7 @@ provider "netapp-ontap" {
   connection_profiles = [
     {
       name     = "aws"
-      hostname = var.fsxn_mgmt_ip
+      hostname = var.fsxn_management_ip
       username = "fsxadmin"
       password = data.aws_secretsmanager_secret_version.fsxn_password.secret_string
       aws_lambda = {

--- a/modules/perforce/helix-core/fsxn.tf
+++ b/modules/perforce/helix-core/fsxn.tf
@@ -1,0 +1,254 @@
+# Fetch FSxN Password Value from Secrets Manager
+data "aws_secretsmanager_secret" "fsxn_password" {
+  arn = var.fsxn_password
+}
+
+data "aws_secretsmanager_secret_version" "fsxn_password" {
+  secret_id = data.aws_secretsmanager_secret.fsxn_password.id
+}
+
+provider "netapp-ontap" {
+  connection_profiles = [
+    {
+      name     = "aws"
+      hostname = var.fsxn_mgmt_ip
+      username = "fsxadmin"
+      password = data.aws_secretsmanager_secret_version.fsxn_password.secret_string
+      aws_lambda = {
+        function_name         = aws_lambda_function.lambda_function[0].function_name
+        region                = data.aws_region.current.name
+        shared_config_profile = var.fsxn_aws_profile
+      }
+    }
+  ]
+}
+
+resource "aws_iam_role" "lambda_role" {
+  count = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  name  = "LambdaLinkRole-link-perforce"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "lambda.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  managed_policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+    "arn:aws:iam::aws:policy/service-role/AWSLambdaRole"
+  ]
+
+  inline_policy {
+    name = "LambdaPolicy"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [
+        {
+          Effect = "Allow"
+          Action = [
+            "ec2:CreateNetworkInterface",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DeleteNetworkInterface",
+            "ec2:AssignPrivateIpAddresses",
+            "ec2:UnassignPrivateIpAddresses"
+          ]
+          Resource = "*"
+        }
+      ]
+    })
+  }
+}
+
+resource "aws_security_group" "fsxn_lambda_link_security_group" {
+  name        = "fsxn-link-sg"
+  description = "Security group for the FSxN Link Lambda."
+  vpc_id      = var.vpc_id
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_egress_rule" "fsxn_lambda_link_security_group_egress_rule" {
+  ip_protocol                  = "TCP"
+  security_group_id            = aws_security_group.fsxn_lambda_link_security_group.id
+  description                  = "Grants outbound access from FSxN Lambda to FSxN filesystem"
+  from_port                    = 443
+  to_port                      = 443
+  referenced_security_group_id = var.fsxn_filesystem_security_group_id
+}
+
+resource "aws_lambda_function" "lambda_function" {
+  count         = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  function_name = "link-perforce"
+  role          = aws_iam_role.lambda_role[count.index].arn
+  package_type  = "Image"
+  image_uri     = "052582346341.dkr.ecr.${var.fsxn_region}.amazonaws.com/fsx_link:production"
+  vpc_config {
+    security_group_ids = [aws_security_group.fsxn_lambda_link_security_group.id]
+    subnet_ids         = [var.instance_subnet_id]
+  }
+  environment {
+    variables = {
+      NODE_TLS_REJECT_UNAUTHORIZED = "0"
+      LATEST                       = "1.0.0"
+    }
+  }
+  timeout = 10
+}
+
+resource "netapp-ontap_protocols_san_igroup_resource" "perforce_igroup" {
+  count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  cx_profile_name = "aws"
+  name            = "perforce"
+  svm = {
+    name = var.fsxn_svm_name
+  }
+  os_type    = "linux"
+  protocol   = "iscsi"
+  depends_on = [aws_lambda_function.lambda_function]
+}
+#
+# resource "netapp-ontap_volume" "logs_vol" {
+#   count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+#   cx_profile_name = "aws"
+#   name            = "logs"
+#   svm_name        = var.fsxn_svm_name
+#   aggregates = [
+#     {
+#       name = "aggr1"
+#     }
+#   ]
+#   space = {
+#     size      = var.logs_volume_size
+#     size_unit = "gb"
+#   }
+#   nas = {
+#     junction_path = "/hxlogs"
+#   }
+#   depends_on = [aws_lambda_function.lambda_function]
+# }
+
+resource "netapp-ontap_lun" "logs_volume_lun" {
+  count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  cx_profile_name = "aws"
+  os_type         = "linux"
+  size            = var.logs_volume_size * 0.75 * 1073741824
+  svm_name        = var.fsxn_svm_name
+  volume_name     = aws_fsx_ontap_volume.logs[0].name
+  name            = "/vol/${aws_fsx_ontap_volume.logs[0].name}/${aws_fsx_ontap_volume.logs[0].name}"
+  depends_on      = [aws_lambda_function.lambda_function]
+}
+
+resource "netapp-ontap_protocols_san_lun-maps_resource" "logs_lun_map" {
+  count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  cx_profile_name = "aws"
+  svm = {
+    name = var.fsxn_svm_name
+  }
+  lun = {
+    name = netapp-ontap_lun.logs_volume_lun[count.index].name
+  }
+  igroup = {
+    name = netapp-ontap_protocols_san_igroup_resource.perforce_igroup[count.index].name
+  }
+  depends_on = [aws_lambda_function.lambda_function]
+}
+
+# resource "netapp-ontap_volume" "metadata_vol" {
+#   count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+#   cx_profile_name = "aws"
+#   name            = "metadata"
+#   svm_name        = var.fsxn_svm_name
+#   aggregates = [
+#     {
+#       name = "aggr1"
+#     }
+#   ]
+#   space = {
+#     size      = var.metadata_volume_size
+#     size_unit = "gb"
+#   }
+#   nas = {
+#     junction_path = "/hxmetadata"
+#   }
+#   depends_on = [aws_lambda_function.lambda_function]
+# }
+
+resource "netapp-ontap_lun" "metadata_volume_lun" {
+  count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  cx_profile_name = "aws"
+  os_type         = "linux"
+  size            = var.metadata_volume_size * 0.75 * 1073741824
+  svm_name        = var.fsxn_svm_name
+  volume_name     = aws_fsx_ontap_volume.metadata[0].name
+  name            = "/vol/${aws_fsx_ontap_volume.metadata[0].name}/${aws_fsx_ontap_volume.metadata[0].name}"
+  depends_on      = [aws_lambda_function.lambda_function]
+}
+
+resource "netapp-ontap_protocols_san_lun-maps_resource" "metadata_lun_map" {
+  count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  cx_profile_name = "aws"
+  svm = {
+    name = var.fsxn_svm_name
+  }
+  lun = {
+    name = netapp-ontap_lun.metadata_volume_lun[count.index].name
+  }
+  igroup = {
+    name = netapp-ontap_protocols_san_igroup_resource.perforce_igroup[count.index].name
+  }
+  depends_on = [aws_lambda_function.lambda_function]
+}
+
+# resource "netapp-ontap_volume" "depots_vol" {
+#   count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+#   cx_profile_name = "aws"
+#   name            = "depot"
+#   svm_name        = var.fsxn_svm_name
+#   aggregates = [
+#     {
+#       name = "aggr1"
+#     }
+#   ]
+#   space = {
+#     size      = var.depot_volume_size
+#     size_unit = "gb"
+#   }
+#   nas = {
+#     junction_path = "/hxdepots"
+#   }
+#   depends_on = [aws_lambda_function.lambda_function]
+# }
+
+resource "netapp-ontap_lun" "depots_volume_lun" {
+  count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  cx_profile_name = "aws"
+  os_type         = "linux"
+  size            = var.depot_volume_size * 0.75 * 1073741824
+  svm_name        = var.fsxn_svm_name
+  volume_name     = aws_fsx_ontap_volume.depot[0].name
+  name            = "/vol/${aws_fsx_ontap_volume.depot[0].name}/${aws_fsx_ontap_volume.depot[0].name}"
+  depends_on      = [aws_lambda_function.lambda_function]
+}
+
+resource "netapp-ontap_protocols_san_lun-maps_resource" "depots_lun_map" {
+  count           = var.storage_type == "FSxN" && var.protocol == "ISCSI" ? 1 : 0
+  cx_profile_name = "aws"
+  svm = {
+    name = var.fsxn_svm_name
+  }
+  lun = {
+    name = netapp-ontap_lun.depots_volume_lun[count.index].name
+  }
+  igroup = {
+    name = netapp-ontap_protocols_san_igroup_resource.perforce_igroup[count.index].name
+  }
+  depends_on = [aws_lambda_function.lambda_function]
+}

--- a/modules/perforce/helix-core/iam.tf
+++ b/modules/perforce/helix-core/iam.tf
@@ -28,10 +28,11 @@ data "aws_iam_policy_document" "helix_core_default_policy" {
       "secretsmanager:DescribeSecret",
       "secretsmanager:BatchGetSecretValue"
     ]
-    resources = [
+    resources = compact([
       var.helix_core_super_user_username_secret_arn == null ? awscc_secretsmanager_secret.helix_core_super_user_username[0].secret_id : var.helix_core_super_user_username_secret_arn,
       var.helix_core_super_user_password_secret_arn == null ? awscc_secretsmanager_secret.helix_core_super_user_password[0].secret_id : var.helix_core_super_user_password_secret_arn,
-    ]
+      var.storage_type == "FSxN" && var.protocol == "ISCSI" ? var.fsxn_password : null
+    ])
   }
 }
 

--- a/modules/perforce/helix-core/main.tf
+++ b/modules/perforce/helix-core/main.tf
@@ -141,42 +141,7 @@ resource "aws_volume_attachment" "depot_attachment" {
   instance_id = aws_instance.helix_core_instance.id
 }
 
-##########################################
-# Storage Configuration - FSxN
-##########################################
 
-// hxlogs
-resource "aws_fsx_ontap_volume" "logs" {
-  count                      = var.storage_type == "FSxN" ? 1 : 0
-  storage_virtual_machine_id = var.amazon_fsxn_svm_id
-  name                       = "logs"
-  size_in_megabytes          = var.logs_volume_size * 1024
-  tags                       = local.tags
-  storage_efficiency_enabled = true
-  junction_path              = "/hxlogs"
-}
-
-// hxmetadata
-resource "aws_fsx_ontap_volume" "metadata" {
-  count                      = var.storage_type == "FSxN" ? 1 : 0
-  storage_virtual_machine_id = var.amazon_fsxn_svm_id
-  name                       = "metadata"
-  size_in_megabytes          = var.metadata_volume_size * 1024
-  tags                       = local.tags
-  storage_efficiency_enabled = true
-  junction_path              = "/hxmetadata"
-}
-
-// hxdepot
-resource "aws_fsx_ontap_volume" "depot" {
-  count                      = var.storage_type == "FSxN" ? 1 : 0
-  storage_virtual_machine_id = var.amazon_fsxn_svm_id
-  name                       = "depot"
-  size_in_megabytes          = var.depot_volume_size * 1024
-  tags                       = local.tags
-  storage_efficiency_enabled = true
-  junction_path              = "/hxdepots"
-}
 
 ##########################################
 # Default SG for Internet Egress

--- a/modules/perforce/helix-core/main.tf
+++ b/modules/perforce/helix-core/main.tf
@@ -93,7 +93,7 @@ resource "aws_instance" "helix_core_instance" {
      ${var.helix_authentication_service_url == null ? "" : "--auth ${var.helix_authentication_service_url}"} \
      ${local.is_fsxn ? "--fsxn_password ${var.fsxn_password}" : null} \
      ${local.is_fsxn ? "--fsxn_svm_name ${var.fsxn_svm_name}" : null} \
-     ${local.is_fsxn ? "--fsxn_mgmt_ip ${var.fsxn_mgmt_ip}" : null} \
+     ${local.is_fsxn ? "--fsxn_management_ip ${var.fsxn_management_ip}" : null} \
      --case_sensitive ${var.helix_case_sensitive ? 1 : 0} \
      --unicode ${var.unicode ? "true" : "false"} \
      --selinux ${var.selinux ? "true" : "false"} \

--- a/modules/perforce/helix-core/outputs.tf
+++ b/modules/perforce/helix-core/outputs.tf
@@ -36,3 +36,8 @@ output "helix_core_private_ip" {
   value       = aws_instance.helix_core_instance.private_ip
   description = "Private IP for the Helix Core instance"
 }
+
+output "fsxn_link_security_group_id" {
+  value       = aws_security_group.fsxn_lambda_link_security_group.id
+  description = "The ID of the security group for the FSxN Link Lambda."
+}

--- a/modules/perforce/helix-core/variables.tf
+++ b/modules/perforce/helix-core/variables.tf
@@ -8,7 +8,7 @@ variable "name" {
 
   validation {
     condition     = length(var.name) > 1 && length(var.name) <= 50
-    error_message = "The defined 'name' has too many characters (${length(var.name)}). This can cause deployment failures for AWS resources with smaller character limits. Please reduce the character count and try again."
+    error_message = "The defined 'name' has too many characters. This can cause deployment failures for AWS resources with smaller character limits. Please reduce the character count and try again."
   }
 }
 
@@ -108,16 +108,16 @@ variable "server_type" {
   description = "The Perforce Helix Core server type."
   validation {
     condition     = contains(["p4d_commit", "p4d_replica"], var.server_type)
-    error_message = "${var.server_type} is not one of p4d_commit or p4d_replica."
+    error_message = "Server type is not one of p4d_commit or p4d_replica."
   }
 }
 
 # tflint-ignore: terraform_unused_declarations
 variable "storage_type" {
   type        = string
-  description = "The type of backing store [EBS, FSxZ]"
+  description = "The type of backing store [EBS, FSxZ, FSxN]"
   validation {
-    condition     = contains(["EBS", "FSxZ"], var.storage_type)
+    condition     = contains(["EBS", "FSxZ", "FSxN"], var.storage_type)
     error_message = "Not a valid storage type."
   }
 }
@@ -140,8 +140,100 @@ variable "depot_volume_size" {
   default     = 128
 }
 
+variable "amazon_fsxn_filesystem_id" {
+  description = "The ID of the existing FSx ONTAP file system to use if storage type is FSxN."
+  type        = string
+  default     = ""
 
-########################################
+  validation {
+    condition     = var.storage_type != "FSxN" || var.protocol != "NFS" || length(var.amazon_fsxn_filesystem_id) > 0
+    error_message = "The amazon_fsxn_filesystem_id variable must be provided when storage_type is FSxN."
+  }
+}
+
+variable "amazon_fsxn_svm_id" {
+  description = "The ID of the Storage Virtual Machine (SVM) for the FSx ONTAP filesystem."
+  type        = string
+  default     = ""
+
+  validation {
+    condition     = var.storage_type != "FSxN" || var.protocol != "NFS" || length(var.amazon_fsxn_svm_id) > 0
+    error_message = "The amazon_fsxn_svm_id variable must be provided when storage_type is FSxN."
+  }
+}
+
+variable "fsxn_region" {
+  description = "The ID of the Storage Virtual Machine (SVM) for the FSx ONTAP filesystem."
+  type        = string
+  default     = "us-west-2"
+
+  validation {
+    condition     = var.storage_type != "FSxN" || length(var.fsxn_region) > 0
+    error_message = "The fsxn_region variable must be provided when storage_type is FSxN."
+  }
+}
+
+variable "protocol" {
+  description = "Specify the protocol (NFS or ISCSI)"
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.storage_type != "FSxN" || contains(["NFS", "ISCSI"], var.protocol)
+    error_message = "The protocol variable must be either 'NFS' or 'ISCSI'."
+  }
+}
+
+variable "fsxn_mgmt_ip" {
+  description = "FSxN management ip address"
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || length(var.fsxn_mgmt_ip) > 0
+    error_message = "The fsxn_mgmt_ip variable must be provided when storage_type is FSxN and ISCSI protocol."
+  }
+}
+
+variable "fsxn_svm_name" {
+  description = "FSxN storage virtual machine name"
+  type        = string
+  default     = "fsx"
+  validation {
+    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || length(var.fsxn_svm_name) > 0
+    error_message = "The fsxn_svm_name variable must be provided when storage_type is FSxN and ISCSI protocol."
+  }
+}
+
+variable "fsxn_password" {
+  description = "FSxN admin user password AWS secret manager arn"
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || length(var.fsxn_password) > 0
+    error_message = "The fsxn_password variable must be provided when storage_type is FSxN and ISCSI protocol."
+  }
+}
+
+variable "fsxn_aws_profile" {
+  description = "FSxN admin user password AWS secret manager arn"
+  type        = string
+  default     = ""
+  validation {
+    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || length(var.fsxn_aws_profile) > 0
+    error_message = "The fsxn_aws_profile variable must be provided when storage_type is FSxN and ISCSI protocol."
+  }
+}
+
+variable "fsxn_filesystem_security_group_id" {
+  description = "The ID of the security group for the FSxN file system."
+  type        = string
+  default     = null
+  validation {
+    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || length(var.fsxn_filesystem_security_group_id) > 0
+    error_message = "The fsxn_filesystem_security_group_id variable must be provided when storage_type is FSxN and ISCSI protocol."
+  }
+}
+
+# ########################################
 # Helix Core Instance Roles
 ########################################
 variable "custom_helix_core_role" {

--- a/modules/perforce/helix-core/variables.tf
+++ b/modules/perforce/helix-core/variables.tf
@@ -228,7 +228,7 @@ variable "fsxn_filesystem_security_group_id" {
   type        = string
   default     = null
   validation {
-    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || length(var.fsxn_filesystem_security_group_id) > 0
+    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || var.fsxn_filesystem_security_group_id != null
     error_message = "The fsxn_filesystem_security_group_id variable must be provided when storage_type is FSxN and ISCSI protocol."
   }
 }

--- a/modules/perforce/helix-core/variables.tf
+++ b/modules/perforce/helix-core/variables.tf
@@ -183,12 +183,12 @@ variable "protocol" {
   }
 }
 
-variable "fsxn_mgmt_ip" {
+variable "fsxn_management_ip" {
   description = "FSxN management ip address"
   type        = string
   default     = ""
   validation {
-    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || length(var.fsxn_mgmt_ip) > 0
+    condition     = var.storage_type != "FSxN" || var.protocol != "ISCSI" || length(var.fsxn_management_ip) > 0
     error_message = "The fsxn_mgmt_ip variable must be provided when storage_type is FSxN and ISCSI protocol."
   }
 }

--- a/modules/perforce/helix-core/versions.tf
+++ b/modules/perforce/helix-core/versions.tf
@@ -14,5 +14,9 @@ terraform {
       source  = "hashicorp/random"
       version = "3.7.1"
     }
+    netapp-ontap = {
+      source  = "NetApp/netapp-ontap"
+      version = "2.1.1"
+    }
   }
 }


### PR DESCRIPTION
**Issue number:**
Closes #428 

## Summary

This PR adds functionality to the Perforce Server (Helix Core) module to leverage FSx for NetApp ONTAP as a backing store. It also provides modifications to the `p4_configure.sh` startup script to mount ISCSI volumes from FSxN, and includes a simple example for deploying Helix Core with an existing FSxN filesystem.

### Changes

> Please provide a summary of what's being changed

- Add ISCSI mounting support to `p4_configure.sh` startup script.
- Adds `fsxn` example which deploys a single-AZ FSxN filesystem and a Helix Core server leveraging that filesystem for storage.
- Adds NetApp resources to the Helix Core module. Leverages the NetApp Terraform provider and the Lambda Link functionality to create filesystem specific resources (LUN, iGroup)

### User experience

> Please share what the user experience looks like before and after this change

Prior to this change a user looking to deploy Helix Core was restricted to EBS storage. They can now set `storage_type = "FSxN"` and provide FSxN related configurations to leverage ISCSI volumes in a FSxN filesystem for backing their P4 Server (Helix Core).

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

No.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.