### PR TITLE
Fix: TeamCity module ALB access log bucket force delete on debug

### DIFF
--- a/modules/teamcity/main.tf
+++ b/modules/teamcity/main.tf
@@ -335,6 +335,7 @@ resource "aws_lb" "teamcity_external_lb" {
   #checkov:skip=CKV_AWS_150:Deletion protection disabled by default
   enable_deletion_protection = var.enable_teamcity_alb_deletion_protection
 
+
   #checkov:skip=CKV2_AWS_28: ALB access is managed with SG allow listing
 
   drop_invalid_header_fields = true
@@ -494,8 +495,9 @@ resource "random_string" "teamcity_alb_access_logs_bucket_suffix" {
 }
 
 resource "aws_s3_bucket" "teamcity_alb_access_logs_bucket" {
-  count  = var.enable_teamcity_alb_access_logs && var.teamcity_alb_access_logs_bucket == null ? 1 : 0
-  bucket = "${local.name_prefix}-alb-access-logs-${random_string.teamcity_alb_access_logs_bucket_suffix[0].result}"
+  count         = var.enable_teamcity_alb_access_logs && var.teamcity_alb_access_logs_bucket == null ? 1 : 0
+  bucket        = "${local.name_prefix}-alb-access-logs-${random_string.teamcity_alb_access_logs_bucket_suffix[0].result}"
+  force_destroy = var.debug
 
   #checkov:skip=CKV_AWS_21: Versioning not necessary for access logs
   #checkov:skip=CKV_AWS_144: Cross-region replication not necessary for access logs


### PR DESCRIPTION
**Issue number:** Closes #577 

## Summary

Added the `force_destroy = var.debug` configuration to the access logs bucket

### Changes

adding `force_destroy = var.debug` to resource `"aws_s3_bucket" "teamcity_alb_access_logs_bucket"`

### User experience

`terraform destroy` will now be able to destroy the module even if the bucket is not empty for debug

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary> 
no

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.