### PR TITLE
fix: update Unreal Horde module IAM deprecations and add container_image variable

### DIFF
--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -6,8 +6,8 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.69.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.6.3 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.89.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.7.1 |
 
 ## Providers
 
@@ -24,80 +24,83 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_autoscaling_group.unreal_horde_agent_asg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/autoscaling_group) | resource |
-| [aws_cloudwatch_log_group.unreal_horde_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_docdb_cluster.horde](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/docdb_cluster) | resource |
-| [aws_docdb_cluster_instance.horde](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/docdb_cluster_instance) | resource |
-| [aws_docdb_cluster_parameter_group.horde](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/docdb_cluster_parameter_group) | resource |
-| [aws_docdb_subnet_group.horde](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/docdb_subnet_group) | resource |
-| [aws_ecs_cluster.unreal_horde_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_cluster) | resource |
-| [aws_ecs_service.unreal_horde](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_service) | resource |
-| [aws_ecs_task_definition.unreal_horde_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ecs_task_definition) | resource |
-| [aws_elasticache_cluster.horde](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/elasticache_cluster) | resource |
-| [aws_elasticache_subnet_group.horde](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/elasticache_subnet_group) | resource |
-| [aws_iam_instance_profile.unreal_horde_agent_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_instance_profile) | resource |
-| [aws_iam_policy.horde_agents_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.unreal_horde_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.unreal_horde_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.unreal_horde_agent_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.unreal_horde_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.unreal_horde_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/iam_role) | resource |
-| [aws_launch_template.unreal_horde_agent_template](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/launch_template) | resource |
-| [aws_lb.unreal_horde_external_alb](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb) | resource |
-| [aws_lb.unreal_horde_internal_alb](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb) | resource |
-| [aws_lb_listener.unreal_horde_external_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener) | resource |
-| [aws_lb_listener.unreal_horde_internal_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener) | resource |
-| [aws_lb_listener_rule.unreal_horde_external_alb_grpc_rule](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener_rule) | resource |
-| [aws_lb_listener_rule.unreal_horde_internal_alb_grpc_rule](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener_rule) | resource |
-| [aws_lb_target_group.unreal_horde_api_target_group_external](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.unreal_horde_api_target_group_internal](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.unreal_horde_grpc_target_group_external](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_target_group) | resource |
-| [aws_lb_target_group.unreal_horde_grpc_target_group_internal](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_target_group) | resource |
-| [aws_s3_bucket.ansible_playbooks](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket.unreal_horde_alb_access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_lifecycle_configuration.access_logs_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_policy.alb_access_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.access_logs_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_public_access_block.ansible_playbooks_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_s3_bucket_versioning.ansible_playbooks_versioning](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_bucket_versioning) | resource |
-| [aws_s3_object.unreal_horde_agent_playbook](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_object) | resource |
-| [aws_s3_object.unreal_horde_agent_service](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/s3_object) | resource |
-| [aws_security_group.unreal_horde_agent_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_security_group.unreal_horde_docdb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_security_group.unreal_horde_elasticache_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_security_group.unreal_horde_external_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_security_group.unreal_horde_internal_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_security_group.unreal_horde_sg](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/security_group) | resource |
-| [aws_ssm_association.configure_unreal_horde_agent](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ssm_association) | resource |
-| [aws_ssm_document.ansible_run_document](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/ssm_document) | resource |
-| [aws_vpc_security_group_egress_rule.unreal_horde_agents_outbound_ipv4](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.unreal_horde_agents_outbound_ipv6](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.unreal_horde_external_alb_outbound_service_api](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.unreal_horde_external_alb_outbound_service_grpc](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.unreal_horde_internal_alb_outbound_service_api](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.unreal_horde_internal_alb_outbound_service_grpc](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.unreal_horde_outbound_ipv4](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.unreal_horde_outbound_ipv6](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.unreal_horde_agents_inbound_agents](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.unreal_horde_docdb_ingress](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.unreal_horde_elasticache_ingress](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.unreal_horde_inbound_external_alb_api](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.unreal_horde_inbound_external_alb_grpc](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.unreal_horde_inbound_internal_alb_api](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.unreal_horde_inbound_internal_alb_grpc](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.unreal_horde_service_inbound_agents](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [random_string.unreal_horde](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
-| [random_string.unreal_horde_alb_access_logs_bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
-| [random_string.unreal_horde_ansible_playbooks_bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/3.6.3/docs/resources/string) | resource |
-| [aws_ecs_cluster.unreal_horde_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/ecs_cluster) | data source |
-| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/elb_service_account) | data source |
-| [aws_iam_policy_document.access_logs_bucket_alb_write](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ec2_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.horde_agents_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.unreal_horde_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.unreal_horde_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/data-sources/region) | data source |
+| [aws_autoscaling_group.unreal_horde_agent_asg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/autoscaling_group) | resource |
+| [aws_cloudwatch_log_group.unreal_horde_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_docdb_cluster.horde](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/docdb_cluster) | resource |
+| [aws_docdb_cluster_instance.horde](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/docdb_cluster_instance) | resource |
+| [aws_docdb_cluster_parameter_group.horde](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/docdb_cluster_parameter_group) | resource |
+| [aws_docdb_subnet_group.horde](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/docdb_subnet_group) | resource |
+| [aws_ecs_cluster.unreal_horde_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_service.unreal_horde](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.unreal_horde_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ecs_task_definition) | resource |
+| [aws_elasticache_cluster.horde](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/elasticache_cluster) | resource |
+| [aws_elasticache_subnet_group.horde](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/elasticache_subnet_group) | resource |
+| [aws_iam_instance_profile.unreal_horde_agent_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_policy.horde_agents_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.unreal_horde_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.unreal_horde_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role.unreal_horde_agent_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.unreal_horde_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.unreal_horde_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.unreal_horde_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.unreal_horde_task_execution_role_ecs](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.unreal_horde_task_execution_role_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_launch_template.unreal_horde_agent_template](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/launch_template) | resource |
+| [aws_lb.unreal_horde_external_alb](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb) | resource |
+| [aws_lb.unreal_horde_internal_alb](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb) | resource |
+| [aws_lb_listener.unreal_horde_external_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.unreal_horde_internal_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_listener) | resource |
+| [aws_lb_listener_rule.unreal_horde_external_alb_grpc_rule](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_listener_rule) | resource |
+| [aws_lb_listener_rule.unreal_horde_internal_alb_grpc_rule](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_listener_rule) | resource |
+| [aws_lb_target_group.unreal_horde_api_target_group_external](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.unreal_horde_api_target_group_internal](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.unreal_horde_grpc_target_group_external](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_target_group) | resource |
+| [aws_lb_target_group.unreal_horde_grpc_target_group_internal](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_target_group) | resource |
+| [aws_s3_bucket.ansible_playbooks](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket.unreal_horde_alb_access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.access_logs_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.alb_access_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.access_logs_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_public_access_block.ansible_playbooks_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_versioning.ansible_playbooks_versioning](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket_versioning) | resource |
+| [aws_s3_object.unreal_horde_agent_playbook](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_object) | resource |
+| [aws_s3_object.unreal_horde_agent_service](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_object) | resource |
+| [aws_security_group.unreal_horde_agent_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
+| [aws_security_group.unreal_horde_docdb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
+| [aws_security_group.unreal_horde_elasticache_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
+| [aws_security_group.unreal_horde_external_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
+| [aws_security_group.unreal_horde_internal_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
+| [aws_security_group.unreal_horde_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
+| [aws_ssm_association.configure_unreal_horde_agent](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ssm_association) | resource |
+| [aws_ssm_document.ansible_run_document](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ssm_document) | resource |
+| [aws_vpc_security_group_egress_rule.unreal_horde_agents_outbound_ipv4](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.unreal_horde_agents_outbound_ipv6](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.unreal_horde_external_alb_outbound_service_api](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.unreal_horde_external_alb_outbound_service_grpc](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.unreal_horde_internal_alb_outbound_service_api](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.unreal_horde_internal_alb_outbound_service_grpc](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.unreal_horde_outbound_ipv4](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.unreal_horde_outbound_ipv6](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.unreal_horde_agents_inbound_agents](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.unreal_horde_docdb_ingress](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.unreal_horde_elasticache_ingress](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.unreal_horde_inbound_external_alb_api](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.unreal_horde_inbound_external_alb_grpc](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.unreal_horde_inbound_internal_alb_api](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.unreal_horde_inbound_internal_alb_grpc](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.unreal_horde_service_inbound_agents](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [random_string.unreal_horde](https://registry.terraform.io/providers/hashicorp/random/3.7.1/docs/resources/string) | resource |
+| [random_string.unreal_horde_alb_access_logs_bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/3.7.1/docs/resources/string) | resource |
+| [random_string.unreal_horde_ansible_playbooks_bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/3.7.1/docs/resources/string) | resource |
+| [aws_ecs_cluster.unreal_horde_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/ecs_cluster) | data source |
+| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/elb_service_account) | data source |
+| [aws_iam_policy_document.access_logs_bucket_alb_write](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ec2_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.horde_agents_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.unreal_horde_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.unreal_horde_secrets_manager_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -112,6 +115,7 @@ No modules.
 | <a name="input_container_api_port"></a> [container\_api\_port](#input\_container\_api\_port) | The container port for the Unreal Horde web server. | `number` | `5000` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | The CPU allotment for the Unreal Horde container. | `number` | `1024` | no |
 | <a name="input_container_grpc_port"></a> [container\_grpc\_port](#input\_container\_grpc\_port) | The container port for the Unreal Horde GRPC channel. | `number` | `5002` | no |
+| <a name="input_container_image"></a> [container\_image](#input\_container\_image) | The container image to use for the Unreal Horde server. | `string` | `"ghcr.io/epicgames/unreal-horde:latest"` | no |
 | <a name="input_container_memory"></a> [container\_memory](#input\_container\_memory) | The memory allotment for the Unreal Horde container. | `number` | `4096` | no |
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | The name of the Unreal Horde container. | `string` | `"unreal-horde-container"` | no |
 | <a name="input_create_external_alb"></a> [create\_external\_alb](#input\_create\_external\_alb) | Set this flag to true to create an external load balancer for Unreal Horde. | `bool` | `true` | no |

--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -115,7 +115,7 @@ No modules.
 | <a name="input_container_api_port"></a> [container\_api\_port](#input\_container\_api\_port) | The container port for the Unreal Horde web server. | `number` | `5000` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | The CPU allotment for the Unreal Horde container. | `number` | `1024` | no |
 | <a name="input_container_grpc_port"></a> [container\_grpc\_port](#input\_container\_grpc\_port) | The container port for the Unreal Horde GRPC channel. | `number` | `5002` | no |
-| <a name="input_container_image"></a> [container\_image](#input\_container\_image) | The container image to use for the Unreal Horde server. | `string` | `"ghcr.io/epicgames/unreal-horde:latest"` | no |
+| <a name="input_container_image"></a> [container\_image](#input\_container\_image) | The container image to use for the Unreal Horde server. | `string` | `"ghcr.io/epicgames/unreal-horde:latest-bundled"` | no |
 | <a name="input_container_memory"></a> [container\_memory](#input\_container\_memory) | The memory allotment for the Unreal Horde container. | `number` | `4096` | no |
 | <a name="input_container_name"></a> [container\_name](#input\_container\_name) | The name of the Unreal Horde container. | `string` | `"unreal-horde-container"` | no |
 | <a name="input_create_external_alb"></a> [create\_external\_alb](#input\_create\_external\_alb) | Set this flag to true to create an external load balancer for Unreal Horde. | `bool` | `true` | no |

--- a/modules/unreal/horde/alb.tf
+++ b/modules/unreal/horde/alb.tf
@@ -234,8 +234,8 @@ resource "random_string" "unreal_horde_alb_access_logs_bucket_suffix" {
 }
 
 resource "aws_s3_bucket" "unreal_horde_alb_access_logs_bucket" {
-  count  = var.enable_unreal_horde_alb_access_logs && var.unreal_horde_alb_access_logs_bucket == null ? 1 : 0
-  bucket = "${local.name_prefix}-alb-access-logs-${random_string.unreal_horde_alb_access_logs_bucket_suffix[0].result}"
+  count         = var.enable_unreal_horde_alb_access_logs && var.unreal_horde_alb_access_logs_bucket == null ? 1 : 0
+  bucket        = "${local.name_prefix}-alb-access-logs-${random_string.unreal_horde_alb_access_logs_bucket_suffix[0].result}"
   force_destroy = true
 
   #checkov:skip=CKV_AWS_21: Versioning not necessary for access logs

--- a/modules/unreal/horde/asg.tf
+++ b/modules/unreal/horde/asg.tf
@@ -133,7 +133,7 @@ resource "aws_s3_bucket" "ansible_playbooks" {
 
   tags                = local.tags
   object_lock_enabled = true
-  force_destroy = true
+  force_destroy       = true
 
 }
 

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -56,11 +56,13 @@ resource "aws_iam_role" "unreal_horde_default_role" {
   name               = "${var.project_prefix}-unreal_horde-default-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
 
-  managed_policy_arns = [
-    aws_iam_policy.unreal_horde_default_policy[0].arn
-  ]
-
   tags = local.tags
+}
+
+resource "aws_iam_role_policy_attachment" "unreal_horde_default_role" {
+  count      = var.create_unreal_horde_default_role ? 1 : 0
+  role       = aws_iam_role.unreal_horde_default_role[0].name
+  policy_arn = aws_iam_policy.unreal_horde_default_policy[0].arn
 }
 
 data "aws_iam_policy_document" "unreal_horde_secrets_manager_policy" {
@@ -82,8 +84,16 @@ resource "aws_iam_policy" "unreal_horde_secrets_manager_policy" {
 }
 
 resource "aws_iam_role" "unreal_horde_task_execution_role" {
-  name = "${var.project_prefix}-unreal_horde-task-execution-role"
+  name               = "${var.project_prefix}-unreal_horde-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
+}
 
-  assume_role_policy  = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
-  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy", aws_iam_policy.unreal_horde_secrets_manager_policy.arn]
+resource "aws_iam_role_policy_attachment" "unreal_horde_task_execution_role_ecs" {
+  role       = aws_iam_role.unreal_horde_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "unreal_horde_task_execution_role_secrets_manager" {
+  role       = aws_iam_role.unreal_horde_task_execution_role.name
+  policy_arn = aws_iam_policy.unreal_horde_secrets_manager_policy.arn
 }

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -8,7 +8,7 @@ resource "random_string" "unreal_horde" {
 data "aws_region" "current" {}
 
 locals {
-  image       = "ghcr.io/epicgames/horde-server:latest-bundled"
+  image       = var.container_image
   name_prefix = "${var.project_prefix}-${var.name}"
   tags = merge(var.tags, {
     "environment" = var.environment

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -112,7 +112,7 @@ variable "desired_container_count" {
 variable "container_image" {
   type        = string
   description = "The container image to use for the Unreal Horde server."
-  default     = "ghcr.io/epicgames/unreal-horde:latest"
+  default     = "ghcr.io/epicgames/unreal-horde:latest-bundled"
 }
 
 ########################################

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -109,6 +109,12 @@ variable "desired_container_count" {
   nullable    = false
 }
 
+variable "container_image" {
+  type        = string
+  description = "The container image to use for the Unreal Horde server."
+  default     = "ghcr.io/epicgames/unreal-horde:latest"
+}
+
 ########################################
 # LOAD BALANCING
 ########################################


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

> Please provide a summary of what's being changed

- Converts the statically defined horde container image string  definedin `local.tf` to use a newly added variable `container_image`. This is a necessary pre-requisite in order to support custom container images as defined in #558.
- Removes the use of deprecated `managed_policy_arns` in favor of `aws_iam_role_policy_attachment`.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.