### PR TITLE
fix(helix swarm): remove helix_swarm_desired_container_count variable from module

### DIFF
--- a/modules/perforce/helix-swarm/main.tf
+++ b/modules/perforce/helix-swarm/main.tf
@@ -176,7 +176,7 @@ resource "aws_ecs_service" "helix_swarm_service" {
   cluster                = var.cluster_name != null ? data.aws_ecs_cluster.helix_swarm_cluster[0].arn : aws_ecs_cluster.helix_swarm_cluster[0].arn
   task_definition        = aws_ecs_task_definition.helix_swarm_task_definition.arn
   launch_type            = "FARGATE"
-  desired_count          = var.helix_swarm_desired_container_count
+  desired_count          = 1 # Helix Swarm does not scale horizontally, so desired container count is fixed at 1
   force_new_deployment   = var.debug
   enable_execute_command = var.debug
 

--- a/modules/perforce/helix-swarm/variables.tf
+++ b/modules/perforce/helix-swarm/variables.tf
@@ -92,12 +92,6 @@ variable "existing_redis_connection" {
   default     = null
 }
 
-variable "helix_swarm_desired_container_count" {
-  type        = number
-  description = "The desired number of containers running the Helix Swarm service."
-  default     = 1
-}
-
 # - Existing Cluster -
 variable "cluster_name" {
   type        = string


### PR DESCRIPTION
**Issue number:** fixes #573 

## Summary

### Changes

> Please provide a summary of what's being changed

This PR removes the `helix_swarm_desired_container_count` variable from the Helix Swarm module, as Helix Swarm does not scale horizontally, and any value greater than 1 would not work.

### User experience

> Please share what the user experience looks like before and after this change

Before: users could configure Helix Swarm in such a way that it wouldn't work - by setting desired_container_count to a value higher than 1. After: users can't configure Helix Swarm incorrectly.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No - although users will need to remove the `helix_swarm_desired_container_count` argument from their `perforce_helix_swarm` module if they've set one.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.