### PR TITLE
Update Perforce complete example with new cidr allowlist variable

### DIFF
--- a/docs/modules/perforce/examples/complete.md
+++ b/docs/modules/perforce/examples/complete.md
@@ -41,33 +41,13 @@ reference architecture. The deployment steps below will get you up and running.
 4. Review the plan provided by the above command. When you are ready to deploy you can confirm by typing "yes" on the
    command line. Terraform will take a few minutes to provision everything. When it completes, you are ready to proceed
    with testing.
-5. By default, none of the deployed resources are available on the public internet. This is to prevent unintended
-   security violations. You can update the security group for the Perforce Network Load balancer through the console, or
-   add the following rules to the example configuration in [
-   `security.tf`](https://github.com/aws-games/cloud-game-development-toolkit/blob/main/modules/perforce/examples/complete/security.tf):
-
-    ```terraform
-   # Grants access on HTTPS port for Helix Swarm and Helix Authentication
-   resource "aws_vpc_security_group_ingress_rule" "private_perforce_https_ingress" {
-      security_group_id = aws_security_group.perforce_network_load_balancer.id
-      description = "Enables private access to Perforce web services."
-      from_port = 443
-      to_port = 443
-      ip_protocol = "TCP"
-      cidr_ipv4 = "<YOUR IP>/32"
-   }
-
-   # Grants access on Helix Core port
-   resource "aws_vpc_security_group_ingress_rule" "private_perforce_https_ingress" {
-      security_group_id = aws_security_group.perforce_network_load_balancer.id
-      description = "Enables private access to Perforce Helix Core."
-      from_port = 1666
-      to_port = 1666
-      ip_protocol = "TCP"
-      cidr_ipv4 = "<YOUR IP>/32"
-
-   }
-    ```
+5. By default, none of the deployed resources are available on the public internet. This is to prevent unintended access to your resources. The perforce example includes a variable `enable_private_access_perforce` that you can configure to allowlist a CIDR to access the deployed Helix Core, Helix Auth, and Helix Swarm servers:
+```
+enable_private_access_perforce = {
+  enabled = true
+  cidr = "x.x.x.x/32"
+}
+```
 6. You should now have access to your deployed resources. The URLs for Helix Swarm and Helix Authentication Service are
    provided as Terraform outputs and should be visible in your console after a successful deployment. The connection
    string for Helix Core is also provided as an output. Use the Helix Core CLI or the P4V application to connect to your

--- a/modules/perforce/examples/complete/README.md
+++ b/modules/perforce/examples/complete/README.md
@@ -90,6 +90,8 @@ To use this example, you must have an existing **public Amazon Route53 Hosted Zo
 | [aws_vpc_security_group_ingress_rule.perforce_helix_core_inbound_web_alb_https](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.perforce_nlb_inbound_helix_core](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.perforce_nlb_inbound_web_alb_https](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.private_perforce_helix_core_ingress](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.private_perforce_https_ingress](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/availability_zones) | data source |
 | [aws_route53_zone.root](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/route53_zone) | data source |
 
@@ -97,6 +99,7 @@ To use this example, you must have an existing **public Amazon Route53 Hosted Zo
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_enable_private_access_perforce"></a> [enable\_private\_access\_perforce](#input\_enable\_private\_access\_perforce) | Enable private access to Perforce and specify allowlisted CIDR range. | <pre>object({<br/>    enabled = bool<br/>    cidr    = string<br/>  })</pre> | `null` | no |
 | <a name="input_root_domain_name"></a> [root\_domain\_name](#input\_root\_domain\_name) | The root domain name you would like to use for DNS. | `string` | n/a | yes |
 
 ## Outputs

--- a/modules/perforce/examples/complete/main.tf
+++ b/modules/perforce/examples/complete/main.tf
@@ -206,25 +206,3 @@ resource "aws_lb_listener" "perforce_web_services_alb" {
     target_group_arn = aws_lb_target_group.perforce_web_services.arn
   }
 }
-
-# Grants access on HTTPS port for Helix Swarm and Helix Authentication
-resource "aws_vpc_security_group_ingress_rule" "private_perforce_https_ingress" {
-  count             = var.enable_private_access_perforce.enabled ? 1 : 0
-  security_group_id = aws_security_group.perforce_network_load_balancer.id
-  description       = "Enables private access to Perforce web services."
-  from_port         = 443
-  to_port           = 443
-  ip_protocol       = "TCP"
-  cidr_ipv4         = var.enable_private_access_perforce.cidr
-}
-
-# Grants access on Helix Core port
-resource "aws_vpc_security_group_ingress_rule" "private_perforce_helix_core_ingress" {
-  count             = var.enable_private_access_perforce.enabled ? 1 : 0
-  security_group_id = aws_security_group.perforce_network_load_balancer.id
-  description       = "Enables private access to Perforce Helix Core."
-  from_port         = 1666
-  to_port           = 1666
-  ip_protocol       = "TCP"
-  cidr_ipv4         = var.enable_private_access_perforce.cidr
-}

--- a/modules/perforce/examples/complete/main.tf
+++ b/modules/perforce/examples/complete/main.tf
@@ -206,3 +206,25 @@ resource "aws_lb_listener" "perforce_web_services_alb" {
     target_group_arn = aws_lb_target_group.perforce_web_services.arn
   }
 }
+
+# Grants access on HTTPS port for Helix Swarm and Helix Authentication
+resource "aws_vpc_security_group_ingress_rule" "private_perforce_https_ingress" {
+  count             = var.enable_private_access_perforce.enabled ? 1 : 0
+  security_group_id = aws_security_group.perforce_network_load_balancer.id
+  description       = "Enables private access to Perforce web services."
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "TCP"
+  cidr_ipv4         = var.enable_private_access_perforce.cidr
+}
+
+# Grants access on Helix Core port
+resource "aws_vpc_security_group_ingress_rule" "private_perforce_helix_core_ingress" {
+  count             = var.enable_private_access_perforce.enabled ? 1 : 0
+  security_group_id = aws_security_group.perforce_network_load_balancer.id
+  description       = "Enables private access to Perforce Helix Core."
+  from_port         = 1666
+  to_port           = 1666
+  ip_protocol       = "TCP"
+  cidr_ipv4         = var.enable_private_access_perforce.cidr
+}

--- a/modules/perforce/examples/complete/security.tf
+++ b/modules/perforce/examples/complete/security.tf
@@ -143,3 +143,28 @@ resource "aws_vpc_security_group_egress_rule" "perforce_helix_swarm_outbound_hel
   ip_protocol                  = "TCP"
   referenced_security_group_id = module.perforce_helix_core.security_group_id
 }
+
+##########################################
+# Optionally enable private access to Perforce
+##########################################
+# Grants access on HTTPS port for Helix Swarm and Helix Authentication
+resource "aws_vpc_security_group_ingress_rule" "private_perforce_https_ingress" {
+  count             = var.enable_private_access_perforce.enabled ? 1 : 0
+  security_group_id = aws_security_group.perforce_network_load_balancer.id
+  description       = "Enables private access to Perforce web services."
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "TCP"
+  cidr_ipv4         = var.enable_private_access_perforce.cidr
+}
+
+# Grants access on Helix Core port
+resource "aws_vpc_security_group_ingress_rule" "private_perforce_helix_core_ingress" {
+  count             = var.enable_private_access_perforce.enabled ? 1 : 0
+  security_group_id = aws_security_group.perforce_network_load_balancer.id
+  description       = "Enables private access to Perforce Helix Core."
+  from_port         = 1666
+  to_port           = 1666
+  ip_protocol       = "TCP"
+  cidr_ipv4         = var.enable_private_access_perforce.cidr
+}

--- a/modules/perforce/examples/complete/variables.tf
+++ b/modules/perforce/examples/complete/variables.tf
@@ -2,3 +2,17 @@ variable "root_domain_name" {
   type        = string
   description = "The root domain name you would like to use for DNS."
 }
+
+
+variable "enable_private_access_perforce" {
+  type = object({
+    enabled = bool
+    cidr    = string
+  })
+  default     = null
+  description = "Enable private access to Perforce and specify allowlisted CIDR range."
+  validation {
+    condition     = var.enable_private_access_perforce.enabled == true && var.enable_private_access_perforce.cidr != null
+    error_message = "If private access to Perforce is enabled, a CIDR range must be provided."
+  }
+}


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

> Please provide a summary of what's being changed

In the Perforce complete example, the documentation provides steps to add a CIDR for allowlisting access to the deployed Perforce Helix Core server and Perforce Web Services NLB. This approach adds additional manual work for users and is error prone as it relies on adding an ingress rule in the AWS console or modifying the terraform module with new resources. To simplify this, this PR proposes removing these options and replace the allowlisting with an optional variable that the user provides when the complete example is deployed.  The documentation for this has also been updated to reflect this update.

### User experience

> Please share what the user experience looks like before and after this change

If a user wants to allowlist a cidr range as part of the complete example, they specify this through a new variable:

```
variable "enable_private_access_perforce" {
  type = object({
    enabled = bool
    cidr    = string
  })
  default     = null
  description = "Enable private access to Perforce and specify allowlisted CIDR range."
  validation {
    condition     = var.enable_private_access_perforce.enabled == true && var.enable_private_access_perforce.cidr != null
    error_message = "If private access to Perforce is enabled, a CIDR range must be provided."
  }
}
```

Example usage:

```
enable_private_access_perforce = {
  enabled = true
  cidr = "x.x.x.x/32"
}
```

With this variable set, the security group ingress rules will be conditionally added:

```
# Grants access on HTTPS port for Helix Swarm and Helix Authentication
resource "aws_vpc_security_group_ingress_rule" "private_perforce_https_ingress" {
  count             = var.enable_private_access_perforce.enabled ? 1 : 0
  security_group_id = aws_security_group.perforce_network_load_balancer.id
  description       = "Enables private access to Perforce web services."
  from_port         = 443
  to_port           = 443
  ip_protocol       = "TCP"
  cidr_ipv4         = var.enable_private_access_perforce.cidr
}

# Grants access on Helix Core port
resource "aws_vpc_security_group_ingress_rule" "private_perforce_helix_core_ingress" {
  count             = var.enable_private_access_perforce.enabled ? 1 : 0
  security_group_id = aws_security_group.perforce_network_load_balancer.id
  description       = "Enables private access to Perforce Helix Core."
  from_port         = 1666
  to_port           = 1666
  ip_protocol       = "TCP"
  cidr_ipv4         = var.enable_private_access_perforce.cidr
}
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.