### PR TITLE
Feat: Valkey support for Elasticache Ltang/horde/valkey

### DIFF
--- a/modules/unreal/horde/elasticache.tf
+++ b/modules/unreal/horde/elasticache.tf
@@ -23,15 +23,16 @@ resource "aws_elasticache_cluster" "horde" {
 
 # Valkey Cluster Mode Disabled
 resource "aws_elasticache_replication_group" "horde" {
-  count                = var.elasticache_engine == "valkey" && var.custom_cache_connection_config == null ? 1 : 0
-  engine               = "valkey"
-  engine_version       = "7.2"
-  replication_group_id = "${var.name}-elasticache-valkey-rep-grp"
-  description          = "valkey for horde"
-  node_type            = var.elasticache_node_type
-  num_cache_clusters   = var.elasticache_cluster_count
-  parameter_group_name = local.elasticache_valkey_parameter_group_name
-  port                 = local.elasticache_port
-  security_group_ids   = [aws_security_group.unreal_horde_elasticache_sg[0].id]
-  subnet_group_name    = aws_elasticache_subnet_group.horde[0].name
+  automatic_failover_enabled = true
+  count                      = var.elasticache_engine == "valkey" && var.custom_cache_connection_config == null ? 1 : 0
+  engine                     = "valkey"
+  engine_version             = "7.2"
+  replication_group_id       = "${var.name}-elasticache-valkey-rep-grp"
+  description                = "valkey for horde"
+  node_type                  = var.elasticache_node_type
+  num_cache_clusters         = var.elasticache_cluster_count
+  parameter_group_name       = local.elasticache_valkey_parameter_group_name
+  port                       = local.elasticache_port
+  security_group_ids         = [aws_security_group.unreal_horde_elasticache_sg[0].id]
+  subnet_group_name          = aws_elasticache_subnet_group.horde[0].name
 }

--- a/modules/unreal/horde/elasticache.tf
+++ b/modules/unreal/horde/elasticache.tf
@@ -7,7 +7,7 @@ resource "aws_elasticache_subnet_group" "horde" {
 
 # Single Node Elasticache Cluster for Horde
 resource "aws_elasticache_cluster" "horde" {
-  count                = var.redis_connection_config == null ? 1 : 0
+  count = var.elasticache_engine == "redis" && var.redis_connection_config == null ? 1 : 0
   cluster_id           = "${var.name}-elasticache-redis-cluster"
   engine               = "redis"
   node_type            = var.elasticache_node_type
@@ -19,4 +19,17 @@ resource "aws_elasticache_cluster" "horde" {
   subnet_group_name    = aws_elasticache_subnet_group.horde[0].name
 
   snapshot_retention_limit = var.elasticache_snapshot_retention_limit
+}
+
+# Valkey Cluster Mode Disabled
+resource "aws_elasticache_replication_group" "horde" {
+  count = var.elasticache_engine == "valkey" && var.redis_connection_config == null ? 1 : 0
+  automatic_failover_enabled  = false # bandaid for "num_cache_clusters": must be at least 2 if automatic_failover_enabled is true
+  preferred_cache_cluster_azs = ["us-west-2a", "us-west-2b"]
+  replication_group_id        = "${var.name}-elasticache-valkey-rep-grp"
+  description                 = "example description"
+  node_type                   = var.elasticache_node_type
+  num_cache_clusters          = var.elasticache_node_count
+  parameter_group_name        = local.elasticache_redis_parameter_group_name
+  port                        = local.elasticache_redis_port
 }

--- a/modules/unreal/horde/elasticache.tf
+++ b/modules/unreal/horde/elasticache.tf
@@ -14,7 +14,7 @@ resource "aws_elasticache_cluster" "horde" {
   num_cache_nodes      = var.elasticache_node_count
   parameter_group_name = local.elasticache_redis_parameter_group_name
   engine_version       = local.elasticache_redis_engine_version
-  port                 = local.elasticache_redis_port
+  port                 = local.elasticache_port
   security_group_ids   = [aws_security_group.unreal_horde_elasticache_sg[0].id]
   subnet_group_name    = aws_elasticache_subnet_group.horde[0].name
 
@@ -27,11 +27,11 @@ resource "aws_elasticache_replication_group" "horde" {
   engine               = "valkey"
   engine_version       = "7.2"
   replication_group_id = "${var.name}-elasticache-valkey-rep-grp"
-  description          = "example description"
+  description          = "valkey for horde"
   node_type            = var.elasticache_node_type
   num_cache_clusters   = var.elasticache_cluster_count
   parameter_group_name = local.elasticache_valkey_parameter_group_name
-  port                 = local.elasticache_redis_port
+  port                 = local.elasticache_port
   security_group_ids   = [aws_security_group.unreal_horde_elasticache_sg[0].id]
   subnet_group_name    = aws_elasticache_subnet_group.horde[0].name
 }

--- a/modules/unreal/horde/elasticache.tf
+++ b/modules/unreal/horde/elasticache.tf
@@ -1,13 +1,13 @@
 # Subnet Group for Horde Elasticache
 resource "aws_elasticache_subnet_group" "horde" {
-  count      = var.redis_connection_config == null ? 1 : 0
+  count      = var.custom_cache_connection_config == null ? 1 : 0
   name       = "${var.name}-elasticache-subnet-group"
   subnet_ids = var.unreal_horde_service_subnets
 }
 
 # Single Node Elasticache Cluster for Horde
 resource "aws_elasticache_cluster" "horde" {
-  count                = var.elasticache_engine == "redis" && var.redis_connection_config == null ? 1 : 0
+  count                = var.elasticache_engine == "redis" && var.custom_cache_connection_config == null ? 1 : 0
   cluster_id           = "${var.name}-elasticache-redis-cluster"
   engine               = "redis"
   node_type            = var.elasticache_node_type
@@ -23,7 +23,7 @@ resource "aws_elasticache_cluster" "horde" {
 
 # Valkey Cluster Mode Disabled
 resource "aws_elasticache_replication_group" "horde" {
-  count                = var.elasticache_engine == "valkey" && var.redis_connection_config == null ? 1 : 0
+  count                = var.elasticache_engine == "valkey" && var.custom_cache_connection_config == null ? 1 : 0
   engine               = "valkey"
   engine_version       = "7.2"
   replication_group_id = "${var.name}-elasticache-valkey-rep-grp"

--- a/modules/unreal/horde/elasticache.tf
+++ b/modules/unreal/horde/elasticache.tf
@@ -7,7 +7,7 @@ resource "aws_elasticache_subnet_group" "horde" {
 
 # Single Node Elasticache Cluster for Horde
 resource "aws_elasticache_cluster" "horde" {
-  count = var.elasticache_engine == "redis" && var.redis_connection_config == null ? 1 : 0
+  count                = var.elasticache_engine == "redis" && var.redis_connection_config == null ? 1 : 0
   cluster_id           = "${var.name}-elasticache-redis-cluster"
   engine               = "redis"
   node_type            = var.elasticache_node_type
@@ -23,13 +23,15 @@ resource "aws_elasticache_cluster" "horde" {
 
 # Valkey Cluster Mode Disabled
 resource "aws_elasticache_replication_group" "horde" {
-  count = var.elasticache_engine == "valkey" && var.redis_connection_config == null ? 1 : 0
-  automatic_failover_enabled  = false # bandaid for "num_cache_clusters": must be at least 2 if automatic_failover_enabled is true
-  preferred_cache_cluster_azs = ["us-west-2a", "us-west-2b"]
-  replication_group_id        = "${var.name}-elasticache-valkey-rep-grp"
-  description                 = "example description"
-  node_type                   = var.elasticache_node_type
-  num_cache_clusters          = var.elasticache_node_count
-  parameter_group_name        = local.elasticache_redis_parameter_group_name
-  port                        = local.elasticache_redis_port
+  count                = var.elasticache_engine == "valkey" && var.redis_connection_config == null ? 1 : 0
+  engine               = "valkey"
+  engine_version       = "7.2"
+  replication_group_id = "${var.name}-elasticache-valkey-rep-grp"
+  description          = "example description"
+  node_type            = var.elasticache_node_type
+  num_cache_clusters   = var.elasticache_cluster_count
+  parameter_group_name = local.elasticache_valkey_parameter_group_name
+  port                 = local.elasticache_redis_port
+  security_group_ids   = [aws_security_group.unreal_horde_elasticache_sg[0].id]
+  subnet_group_name    = aws_elasticache_subnet_group.horde[0].name
 }

--- a/modules/unreal/horde/elasticache.tf
+++ b/modules/unreal/horde/elasticache.tf
@@ -12,27 +12,27 @@ resource "aws_elasticache_cluster" "horde" {
   engine               = "redis"
   node_type            = var.elasticache_node_type
   num_cache_nodes      = var.elasticache_node_count
-  parameter_group_name = local.elasticache_redis_parameter_group_name
-  engine_version       = local.elasticache_redis_engine_version
-  port                 = local.elasticache_port
+  parameter_group_name = var.elasticache_redis_parameter_group_name
+  engine_version       = var.elasticache_redis_engine_version
+  port                 = var.elasticache_port
   security_group_ids   = [aws_security_group.unreal_horde_elasticache_sg[0].id]
   subnet_group_name    = aws_elasticache_subnet_group.horde[0].name
 
   snapshot_retention_limit = var.elasticache_snapshot_retention_limit
 }
 
-# Valkey Cluster Mode Disabled
+# Valkey with Cluster Mode Disabled
 resource "aws_elasticache_replication_group" "horde" {
   automatic_failover_enabled = true
   count                      = var.elasticache_engine == "valkey" && var.custom_cache_connection_config == null ? 1 : 0
   engine                     = "valkey"
-  engine_version             = "7.2"
+  engine_version             = var.elasticache_valkey_engine_version
   replication_group_id       = "${var.name}-elasticache-valkey-rep-grp"
-  description                = "valkey for horde"
+  description                = "Valkey for Unreal Engine Horde"
   node_type                  = var.elasticache_node_type
   num_cache_clusters         = var.elasticache_cluster_count
-  parameter_group_name       = local.elasticache_valkey_parameter_group_name
-  port                       = local.elasticache_port
+  parameter_group_name       = var.elasticache_valkey_parameter_group_name
+  port                       = var.elasticache_port
   security_group_ids         = [aws_security_group.unreal_horde_elasticache_sg[0].id]
   subnet_group_name          = aws_elasticache_subnet_group.horde[0].name
 }

--- a/modules/unreal/horde/examples/complete/main.tf
+++ b/modules/unreal/horde/examples/complete/main.tf
@@ -17,7 +17,7 @@ module "unreal_engine_horde" {
   certificate_arn                   = aws_acm_certificate.unreal_engine_horde.arn
   github_credentials_secret_arn     = var.github_credentials_secret_arn
   tags                              = local.tags
-
+  elasticache_engine                = "redis"
   agents = {
     ubuntu-x86 = {
       ami           = data.aws_ami.ubuntu_noble_amd.id

--- a/modules/unreal/horde/examples/complete/main.tf
+++ b/modules/unreal/horde/examples/complete/main.tf
@@ -17,7 +17,7 @@ module "unreal_engine_horde" {
   certificate_arn                   = aws_acm_certificate.unreal_engine_horde.arn
   github_credentials_secret_arn     = var.github_credentials_secret_arn
   tags                              = local.tags
-  elasticache_engine                = "redis"
+  elasticache_engine                = "valkey"
   agents = {
     ubuntu-x86 = {
       ami           = data.aws_ami.ubuntu_noble_amd.id

--- a/modules/unreal/horde/examples/complete/versions.tf
+++ b/modules/unreal/horde/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.69.0"
+      version = "5.89.0"
     }
   }
 }

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "unreal_horde_default_policy" {
   }
 }
 data "aws_iam_policy_document" "unreal_horde_elasticache_policy" {
-  count = var.redis_connection_config == null ? 1 : 0
+  count = var.custom_cache_connection_config == null ? 1 : 0
   # Elasticache
   statement {
     sid    = "ElasticacheConnect"
@@ -56,7 +56,7 @@ resource "aws_iam_policy" "unreal_horde_default_policy" {
 }
 
 resource "aws_iam_policy" "unreal_horde_elasticache_policy" {
-  count = var.redis_connection_config == null ? 1 : 0
+  count = var.custom_cache_connection_config == null ? 1 : 0
 
   name        = "${var.project_prefix}-unreal_horde-elasticache-policy"
   description = "Policy granting elasticache connect permissions for Unreal Horde."
@@ -78,7 +78,7 @@ resource "aws_iam_role" "unreal_horde_default_role" {
 
 #conditionally attach elasticache policy to default role
 resource "aws_iam_role_policy_attachment" "unreal_horde_elasticache_policy_attachment" {
-  count = var.redis_connection_config == null ? 1 : 0
+  count = var.custom_cache_connection_config == null ? 1 : 0
 
   role       = aws_iam_role.unreal_horde_default_role[0].name
   policy_arn = aws_iam_policy.unreal_horde_elasticache_policy[0].arn

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -37,7 +37,7 @@ data "aws_iam_policy_document" "unreal_horde_default_policy" {
       "elasticache:Connect"
     ]
     resources = [
-      aws_elasticache_cluster.horde[0].arn,
+      aws_elasticache_replication_group.horde[0].arn,
     ]
   }
 }

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -29,6 +29,9 @@ data "aws_iam_policy_document" "unreal_horde_default_policy" {
       "*"
     ]
   }
+}
+data "aws_iam_policy_document" "unreal_horde_elasticache_policy" {
+  count = var.redis_connection_config == null ? 1 : 0
   # Elasticache
   statement {
     sid    = "ElasticacheConnect"
@@ -36,11 +39,13 @@ data "aws_iam_policy_document" "unreal_horde_default_policy" {
     actions = [
       "elasticache:Connect"
     ]
-    resources = [
-      aws_elasticache_replication_group.horde[0].arn,
-    ]
+    resources = (var.elasticache_engine == "redis" ?
+      [aws_elasticache_cluster.horde[0].arn] :
+    [aws_elasticache_replication_group.horde[0].arn])
+
   }
 }
+
 
 resource "aws_iam_policy" "unreal_horde_default_policy" {
   count = var.create_unreal_horde_default_policy ? 1 : 0
@@ -48,6 +53,14 @@ resource "aws_iam_policy" "unreal_horde_default_policy" {
   name        = "${var.project_prefix}-unreal_horde-default-policy"
   description = "Policy granting permissions for Unreal Horde."
   policy      = data.aws_iam_policy_document.unreal_horde_default_policy[0].json
+}
+
+resource "aws_iam_policy" "unreal_horde_elasticache_policy" {
+  count = var.redis_connection_config == null ? 1 : 0
+
+  name        = "${var.project_prefix}-unreal_horde-elasticache-policy"
+  description = "Policy granting elasticache connect permissions for Unreal Horde."
+  policy      = data.aws_iam_policy_document.unreal_horde_elasticache_policy[0].json
 }
 
 resource "aws_iam_role" "unreal_horde_default_role" {
@@ -62,6 +75,15 @@ resource "aws_iam_role" "unreal_horde_default_role" {
 
   tags = local.tags
 }
+
+#conditionally attach elasticache policy to default role
+resource "aws_iam_role_policy_attachment" "unreal_horde_elasticache_policy_attachment" {
+  count = var.redis_connection_config == null ? 1 : 0
+
+  role       = aws_iam_role.unreal_horde_default_role[0].name
+  policy_arn = aws_iam_policy.unreal_horde_elasticache_policy[0].arn
+}
+
 
 data "aws_iam_policy_document" "unreal_horde_secrets_manager_policy" {
   count = var.github_credentials_secret_arn != null ? 1 : 0

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -13,18 +13,18 @@ locals {
     "environment" = var.environment
   })
 
-  elasticache_redis_port                 = 6379
+  elasticache_port                       = 6379
   elasticache_redis_engine_version       = "7.0"
   elasticache_redis_parameter_group_name = "default.redis7"
 
-  #code for valkey, might be better as a variable later
+
   elasticache_valkey_engine_version       = "7.2"
   elasticache_valkey_parameter_group_name = "default.valkey7"
 
 
-  elasticache_redis_connection_strings = [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"]
+  elasticache_redis_connection_strings = var.elasticache_engine == "redis" ? [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"] : null
 
-  elasticache_valkey_connection_strings = var.elasticache_engine == "valkey" ? "${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${local.elasticache_redis_port}" : null
+  elasticache_valkey_connection_strings = var.elasticache_engine == "valkey" ? "${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${local.elasticache_port}" : null
 
   redis_connection_config = var.redis_connection_config != null ? var.redis_connection_config : (var.elasticache_engine == "redis" ? join(",", local.elasticache_redis_connection_strings) : local.elasticache_valkey_connection_strings)
 

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -13,15 +13,9 @@ locals {
     "environment" = var.environment
   })
 
-  elasticache_port = 6379
+  elasticache_redis_connection_strings = var.elasticache_engine == "redis" ? [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"] : null
 
-  elasticache_redis_engine_version       = "7.0"
-  elasticache_redis_parameter_group_name = "default.redis7"
-  elasticache_redis_connection_strings   = var.elasticache_engine == "redis" ? [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"] : null
-
-  elasticache_valkey_engine_version       = "7.2"
-  elasticache_valkey_parameter_group_name = "default.valkey7"
-  elasticache_valkey_connection_strings   = var.elasticache_engine == "valkey" ? "${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${local.elasticache_port}" : null
+  elasticache_valkey_connection_strings = var.elasticache_engine == "valkey" ? "${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${var.elasticache_port}" : null
 
   redis_connection_config = var.custom_cache_connection_config != null ? var.custom_cache_connection_config : (var.elasticache_engine == "redis" ? join(",", local.elasticache_redis_connection_strings) : local.elasticache_valkey_connection_strings)
 

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -13,20 +13,17 @@ locals {
     "environment" = var.environment
   })
 
-  elasticache_port                       = 6379
+  elasticache_port = 6379
+
   elasticache_redis_engine_version       = "7.0"
   elasticache_redis_parameter_group_name = "default.redis7"
-
+  elasticache_redis_connection_strings   = var.elasticache_engine == "redis" ? [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"] : null
 
   elasticache_valkey_engine_version       = "7.2"
   elasticache_valkey_parameter_group_name = "default.valkey7"
+  elasticache_valkey_connection_strings   = var.elasticache_engine == "valkey" ? "${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${local.elasticache_port}" : null
 
-
-  elasticache_redis_connection_strings = var.elasticache_engine == "redis" ? [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"] : null
-
-  elasticache_valkey_connection_strings = var.elasticache_engine == "valkey" ? "${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${local.elasticache_port}" : null
-
-  redis_connection_config = var.redis_connection_config != null ? var.redis_connection_config : (var.elasticache_engine == "redis" ? join(",", local.elasticache_redis_connection_strings) : local.elasticache_valkey_connection_strings)
+  redis_connection_config = var.custom_cache_connection_config != null ? var.custom_cache_connection_config : (var.elasticache_engine == "redis" ? join(",", local.elasticache_redis_connection_strings) : local.elasticache_valkey_connection_strings)
 
   database_connection_string = var.database_connection_string != null ? var.database_connection_string : "mongodb://${var.docdb_master_username}:${var.docdb_master_password}@${aws_docdb_cluster.horde[0].endpoint}:27017/?tls=true&tlsCAFile=/app/config/global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
 

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -14,11 +14,16 @@ locals {
   })
 
   elasticache_redis_port                 = 6379
-  elasticache_redis_engine_version       = "7.0"
-  elasticache_redis_parameter_group_name = "default.redis7"
+  #elasticache_redis_engine_version       = "7.0"
+  #elasticache_redis_parameter_group_name = "default.redis7"
+  elasticache_engine = "valkey"
+  elasticache_redis_engine_version       = "7.2"
+  elasticache_redis_parameter_group_name = "default.valkey7"
 
-  elasticache_connection_strings = [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"]
-
+ 
+#elasticache_connection_strings = [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"]
+  elasticache_connection_strings = [for node in aws_elasticache_replication_group.horde.member_clusters : "${endpoint}:${aws_elasticache_replication_group.horde.port}"]
+  
   redis_connection_config    = var.redis_connection_config != null ? var.redis_connection_config : join(",", local.elasticache_connection_strings)
   database_connection_string = var.database_connection_string != null ? var.database_connection_string : "mongodb://${var.docdb_master_username}:${var.docdb_master_password}@${aws_docdb_cluster.horde[0].endpoint}:27017/?tls=true&tlsCAFile=/app/config/global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
 

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -14,17 +14,20 @@ locals {
   })
 
   elasticache_redis_port                 = 6379
-  #elasticache_redis_engine_version       = "7.0"
-  #elasticache_redis_parameter_group_name = "default.redis7"
-  elasticache_engine = "valkey"
-  elasticache_redis_engine_version       = "7.2"
-  elasticache_redis_parameter_group_name = "default.valkey7"
+  elasticache_redis_engine_version       = "7.0"
+  elasticache_redis_parameter_group_name = "default.redis7"
 
- 
-#elasticache_connection_strings = [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"]
-  elasticache_connection_strings = [for node in aws_elasticache_replication_group.horde.member_clusters : "${endpoint}:${aws_elasticache_replication_group.horde.port}"]
-  
-  redis_connection_config    = var.redis_connection_config != null ? var.redis_connection_config : join(",", local.elasticache_connection_strings)
+  #code for valkey, might be better as a variable later
+  elasticache_valkey_engine_version       = "7.2"
+  elasticache_valkey_parameter_group_name = "default.valkey7"
+
+
+  elasticache_redis_connection_strings = [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"]
+
+  elasticache_valkey_connection_strings = var.elasticache_engine == "valkey" ? "${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${local.elasticache_redis_port}" : null
+
+  redis_connection_config = var.redis_connection_config != null ? var.redis_connection_config : (var.elasticache_engine == "redis" ? join(",", local.elasticache_redis_connection_strings) : local.elasticache_valkey_connection_strings)
+
   database_connection_string = var.database_connection_string != null ? var.database_connection_string : "mongodb://${var.docdb_master_username}:${var.docdb_master_password}@${aws_docdb_cluster.horde[0].endpoint}:27017/?tls=true&tlsCAFile=/app/config/global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
 
   horde_service_env = [for config in [

--- a/modules/unreal/horde/sg.tf
+++ b/modules/unreal/horde/sg.tf
@@ -139,7 +139,7 @@ resource "aws_vpc_security_group_ingress_rule" "unreal_horde_inbound_internal_al
 
 # unreal_horde Elasticache Redis Security Group
 resource "aws_security_group" "unreal_horde_elasticache_sg" {
-  count = var.redis_connection_config == null ? 1 : 0
+  count = var.custom_cache_connection_config == null ? 1 : 0
   #checkov:skip=CKV2_AWS_5:Security group is attached to Elasticache cluster
   name        = "${local.name_prefix}-elasticache"
   vpc_id      = var.vpc_id
@@ -147,7 +147,7 @@ resource "aws_security_group" "unreal_horde_elasticache_sg" {
   tags        = local.tags
 }
 resource "aws_vpc_security_group_ingress_rule" "unreal_horde_elasticache_ingress" {
-  count = var.redis_connection_config == null ? 1 : 0
+  count = var.custom_cache_connection_config == null ? 1 : 0
 
   security_group_id            = aws_security_group.unreal_horde_elasticache_sg[0].id
   description                  = "Allow inbound traffic from unreal_horde service to Redis"

--- a/modules/unreal/horde/sg.tf
+++ b/modules/unreal/horde/sg.tf
@@ -152,8 +152,8 @@ resource "aws_vpc_security_group_ingress_rule" "unreal_horde_elasticache_ingress
   security_group_id            = aws_security_group.unreal_horde_elasticache_sg[0].id
   description                  = "Allow inbound traffic from unreal_horde service to Redis"
   referenced_security_group_id = aws_security_group.unreal_horde_sg.id
-  from_port                    = local.elasticache_port
-  to_port                      = local.elasticache_port
+  from_port                    = var.elasticache_port
+  to_port                      = var.elasticache_port
   ip_protocol                  = "tcp"
 }
 

--- a/modules/unreal/horde/sg.tf
+++ b/modules/unreal/horde/sg.tf
@@ -152,8 +152,8 @@ resource "aws_vpc_security_group_ingress_rule" "unreal_horde_elasticache_ingress
   security_group_id            = aws_security_group.unreal_horde_elasticache_sg[0].id
   description                  = "Allow inbound traffic from unreal_horde service to Redis"
   referenced_security_group_id = aws_security_group.unreal_horde_sg.id
-  from_port                    = local.elasticache_redis_port
-  to_port                      = local.elasticache_redis_port
+  from_port                    = local.elasticache_port
+  to_port                      = local.elasticache_port
   ip_protocol                  = "tcp"
 }
 

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -359,7 +359,7 @@ variable "docdb_storage_encrypted" {
 variable "elasticache_engine" {
   description = "The engine to use for ElastiCache (redis or valkey)"
   type        = string
-  default     = "valkey"
+  default     = "redis"
   validation {
     condition     = contains(["redis", "valkey"], var.elasticache_engine)
     error_message = "Invalid engine. Must be one of: redis, valkey"

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -356,6 +356,12 @@ variable "docdb_storage_encrypted" {
 # ELASTICACHE CONFIG
 ######################
 
+variable "elasticache_engine" {
+  description = "The engine to use for ElastiCache (redis or valkey)"
+  type        = string
+  default     = "valkey"
+}
+
 variable "redis_connection_config" {
   type        = string
   description = "The redis connection configuration that Horde should use."

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -366,9 +366,35 @@ variable "elasticache_engine" {
   }
 }
 
+variable "elasticache_redis_engine_version" {
+  type        = string
+  description = "The version of the Redis engine to use."
+  default     = "7.0"
+}
+variable "elasticache_valkey_engine_version" {
+  type        = string
+  description = "The version of the ElastiCache engine to use."
+  default     = "7.2"
+}
+
+variable "elasticache_redis_parameter_group_name" {
+  type        = string
+  description = "The name of the Redis parameter group to use."
+  default     = "default.redis7"
+}
+variable "elasticache_valkey_parameter_group_name" {
+  type        = string
+  description = "The name of the Valkey parameter group to use."
+  default     = "default.valkey7"
+}
+variable "elasticache_port" {
+  type        = number
+  description = "The port for the ElastiCache cluster."
+  default     = 6379
+}
 variable "elasticache_cluster_count" {
   type        = number
-  description = "Number of cache cluster to provision in the Elasticache valkey cluster."
+  description = "Number of cache cluster to provision in the Elasticache cluster."
   default     = 2
 }
 

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -372,9 +372,9 @@ variable "elasticache_cluster_count" {
   default     = 2
 }
 
-variable "redis_connection_config" {
+variable "custom_cache_connection_config" {
   type        = string
-  description = "The redis connection configuration that Horde should use."
+  description = "The redis-compatible connection configuration that Horde should use."
   default     = null
 }
 

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -360,6 +360,16 @@ variable "elasticache_engine" {
   description = "The engine to use for ElastiCache (redis or valkey)"
   type        = string
   default     = "valkey"
+  validation {
+    condition     = contains(["redis", "valkey"], var.elasticache_engine)
+    error_message = "Invalid engine. Must be one of: redis, valkey"
+  }
+}
+
+variable "elasticache_cluster_count" {
+  type        = number
+  description = "Number of cache cluster to provision in the Elasticache valkey cluster."
+  default     = 2
 }
 
 variable "redis_connection_config" {


### PR DESCRIPTION
**Issue number:**
closes #509

## Summary
Implemented Valkey as a supported elasticache engine type when deploying Horde. It is now the default engine.

### Changes

> Please provide a summary of what's being changed

Valkey can be deployed as a replication group instead of as a Redis cluster. Generalized some variable names to be non-Redis exclusive. Added appropriate conditionals to IAM permissions

### User experience

> Please share what the user experience looks like before and after this change

From the main.tf, user can change engine:

elasticache_engine                = "valkey"
to 
elasticache_engine                = "redis"

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [Yes] I have performed a self-review of this change
* [Yes] Changes have been tested
* [See Below] Changes are documented

### Documentation
Henry would like this change to be documented on https://aws-games.github.io/cloud-game-development-toolkit/latest/modules/unreal/horde/unreal-engine-horde.html

Right now information on Horde is split under Unreal Engine Horde and Examples. This needs to be further organized and may affect the placement of the valkey documentation


### Draft of documentation

The Cloud Game Development Toolkit supports the deployment of Horde with Redis as a cluster or Valkey as a replication group. To change engines, change the elasticache_engine parameter to be either "redis' or "valkey" in modules/horde/examples/complete/main.tf



<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.