### PR TITLE
chore: Add Terraform tests for new Perforce module

### DIFF
--- a/.github/workflows/tf-test-on-comment-modules-perforce.yml
+++ b/.github/workflows/tf-test-on-comment-modules-perforce.yml
@@ -13,12 +13,8 @@ jobs:
   terraform-testing:
     # TODO: scope these permissions down
     permissions: write-all
-    # permissions:
-    #   id-token: write # This is required for AWS OIDC connection
-    #   contents: read # This is required for actions/checkout
-    #   pull-requests: write # This is required for GitHub bot to comment on PR
     name: Terraform Testing
-    # Only run if it#s a PR and the comment contains '/run-perforce-module-tf-tests'
+    # Only run if it is a PR and the comment contains '/run-perforce-module-tf-tests'
     if: github.event.issue.pull_request && contains(github.event.comment.body, '/run-perforce-module-tf-tests')
     runs-on: ubuntu-latest
     environment: aws-ci

--- a/.github/workflows/tf-test-on-comment-modules-perforce.yml
+++ b/.github/workflows/tf-test-on-comment-modules-perforce.yml
@@ -1,0 +1,140 @@
+name: "Invoke Terraform test on Comment for Perforce module"
+
+# https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows
+on:
+  issue_comment:
+    types: [created]
+
+env:
+  TF_LOG: INFO
+  AWS_REGION: ${{vars.AWS_REGION}}
+
+jobs:
+  terraform-testing:
+    # TODO: scope these permissions down
+    permissions: write-all
+    # permissions:
+    #   id-token: write # This is required for AWS OIDC connection
+    #   contents: read # This is required for actions/checkout
+    #   pull-requests: write # This is required for GitHub bot to comment on PR
+    name: Terraform Testing
+    # Only run if it#s a PR and the comment contains '/run-perforce-module-tf-tests'
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/run-perforce-module-tf-tests')
+    runs-on: ubuntu-latest
+    environment: aws-ci
+
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/modules/perforce/
+
+    steps:
+      # Comment on PR that the workflow has been scheduled
+      - name: Comment on PR that the workflow has been scheduled
+        uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            const name = '${{ github.workflow	}}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const body = `Terraform tests have been scheduled 🧪 \n${url}`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
+
+      # Get branch of PR
+      - name: Get branch of PR
+        uses: xt0rted/pull-request-comment-branch@v1
+        id: comment-branch
+
+      # Set latest commit status as pending
+      - name: Set latest commit status as pending
+        uses: myrotvorets/set-commit-status-action@master
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+
+      # Comment on PR that the workflow is in progress
+      - name: Comment on PR that the workflow is in progress
+        uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            const name = '${{ github.workflow	}}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const body = `Terraform tests are in progress ⏳ \n${url}`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
+
+      # Checkout the PR branch
+      - name: Checkout PR branch ${{ steps.comment-branch.outputs.head_ref }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+
+      # Use GitHub Action secret to assume existing AWS IAM Role using OIDC connection
+      - name: Configure AWS credentials from AWS account
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{secrets.AWS_CI_ROLE_ARN}}
+          aws-region: ${{vars.AWS_REGION}}
+          role-session-name: GitHub-OIDC-Terraform
+
+      # Install the preferred version of the Terraform CLI
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+            terraform_version: 1.11.0
+
+      # Format the Terraform code, continue even if there is an error
+      - name: Terraform fmt
+        id: fmt
+        run: terraform fmt -check
+        continue-on-error: true
+
+        # Initialize a new or existing Terraform working directory
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      # Run the actual Terraform tests
+      - name: Terraform Test
+        id: test
+        run: terraform test
+        # run terraform test -filter="tests/<your-desired-test>"
+
+      # 7. Comment on PR the result of the workflow
+      - name: Add workflow result as comment on PR
+        uses: actions/github-script@v6
+        if: always()
+        with:
+          script: |
+            const name = '${{ github.workflow	}}';
+            const url = '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}';
+            const success = '${{ job.status }}' === 'success';
+            const body = `${name}: ${success ? '✅ The Terraform tests have completed successfully. Time for some Choreography and Merriment! 🪩' : '❌ The Terraform tests have completed with errors. Please review the failed GitHub action to resolve. Lumon expects more from you. 🙁'}\n${url}`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            })
+
+      # 8. Set the latest commit status to be the job status
+      - name: Set latest commit status as ${{ job.status }}
+        uses: myrotvorets/set-commit-status-action@master
+        if: always()
+        with:
+          sha: ${{ steps.comment-branch.outputs.head_sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: ${{ job.status }}

--- a/modules/perforce/tests/01_create_resources_complete.tftest.hcl
+++ b/modules/perforce/tests/01_create_resources_complete.tftest.hcl
@@ -1,0 +1,27 @@
+# Fetch relevant values from SSM Parameter Store
+run "setup" {
+  command = plan
+  module {
+    source = "./tests/setup"
+  }
+}
+
+run "unit_test" {
+  command = plan
+
+  variables {
+    route53_public_hosted_zone_name = run.setup.route53_public_hosted_zone_name
+  }
+  module {
+    source = "./examples/create-resources-complete"
+  }
+}
+
+# Unused until error handling/retry logic is improved in Terraform test
+# https://github.com/hashicorp/terraform/issues/36846#issuecomment-2820247524
+# run "e2e_test" {
+#   command = apply
+#   module {
+#     source = "./examples/create-resources-complete"
+#   }
+# }

--- a/modules/perforce/tests/02_p4_server_fsxn.tftest.hcl
+++ b/modules/perforce/tests/02_p4_server_fsxn.tftest.hcl
@@ -1,0 +1,28 @@
+# Fetch relevant values from SSM Parameter Store
+run "setup" {
+  command = plan
+  module {
+    source = "./tests/setup"
+  }
+}
+run "unit_test" {
+  command = plan
+
+  variables {
+    route53_public_hosted_zone_name = run.setup.route53_public_hosted_zone_name
+    fsxn_password                   = run.setup.fsxn_password
+    fsxn_aws_profile                = run.setup.fsxn_aws_profile
+  }
+  module {
+    source = "./examples/p4-server-fsxn"
+  }
+}
+
+# Unused until error handling/retry logic is improved in Terraform test
+# https://github.com/hashicorp/terraform/issues/36846#issuecomment-2820247524
+# # run "e2e_test" {
+# #   command = apply
+# #   module {
+# #     source = "./examples/p4-server-fsxn"
+# #   }
+# # }

--- a/modules/perforce/tests/setup/ssm.tf
+++ b/modules/perforce/tests/setup/ssm.tf
@@ -1,0 +1,24 @@
+# Fetch relevant values from SSM Parameter Store
+data "aws_ssm_parameter" "route53_public_hosted_zone_name" {
+  name = "/cloud-game-development-toolkit/modules/perforce/route53-public-hosted-zone-name"
+}
+data "aws_ssm_parameter" "fsxn_password" {
+  name = "/cloud-game-development-toolkit/modules/perforce/fsxn-password"
+}
+data "aws_ssm_parameter" "fsxn_aws_profile" {
+  name = "/cloud-game-development-toolkit/modules/perforce/fsxn-aws-profile"
+}
+
+
+output "route53_public_hosted_zone_name" {
+  value     = nonsensitive(data.aws_ssm_parameter.route53_public_hosted_zone_name.value)
+  sensitive = false
+}
+output "fsxn_password" {
+  value     = nonsensitive(data.aws_ssm_parameter.fsxn_password.value)
+  sensitive = false
+}
+output "fsxn_aws_profile" {
+  value     = nonsensitive(data.aws_ssm_parameter.fsxn_aws_profile.value)
+  sensitive = false
+}


### PR DESCRIPTION
**Issue number:**
Closes #480 

## Summary
This PR adds tests for the new Perforce module by leveraging `terraform test` functionality. As mentioned in #480, currently this is scoped to only perform simple unit testing (with `terraform plan`) until Terraform is updated to allow for more robust error handling and retry logic for `terraform test`, especially where state is concerned.

### Changes

> Please provide a summary of what's being changed

This PR adds a new workflow file and related Terraform test files that are specific to the new Perforce module, and will test all of the current example implementations of the Perforce module. The goal is that this will allow basic automated tests for the module as additional functionality is added to it. When new functionality is added, additional examples and tests should be created simultaneously. This will allow both contributors and project maintainers to test PRs in a more scalable manner, helping to ensure code changes for net new additions function properly, and do not break any existing functionality.

The tests currently are invoked by commenting on the PR `/run-perforce-module-tf-tests` which will run the tests using a targeted `working-directory`:
```yaml
    defaults:
      run:
        working-directory: ${{ github.workspace }}/modules/perforce/
```

Within the tests, SSM Parameters of necessary values (input variables the example configurations require) are referenced from the relevant internal AWS account that is being used for CI for the toolkit. For additional tests within this module or for any module, this should be standardized - additional parameters added to the CI account, and using a `setup` module within the test to fetch those values and use them within the defined tests. This prevents hardcoding any potential secret values.

For additional module tests, for now we can make additional test files within the modules, that aligns to the example being used for the test. I recommend this take the naming of `01_<example name>.tftest.hcl` such as:
- `/modules/teamcity/tests/01_simple.tftest.hcl`
- `/modules/unreal/horde/tests/01_complete.tftest.hcl` 
- etc

and related workflow files taking the naming of `tf-test-on-comment-modules-<module name>.yml` such as:
- `tf-test-on-comment-modules-teamcity.yml`
- `tf-test-on-comment-modules-horde.yaml`
- etc

This allows to scope tests to the the modules, and easily run all tests for a desired module. Some of this functionality can likely be reused to run **all tests for all modules** when cutting a new release of the toolkit.

### User experience

> Please share what the user experience looks like before and after this change

This change is transparent to end users, and only directly impacts contributors and project maintainers in the manner mentioned above.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.