### PR TITLE
feat(horde): add HTTP redirect listeners to ALBs

### DIFF
--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -65,7 +65,9 @@ No modules.
 | [aws_lb.unreal_horde_external_alb](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb) | resource |
 | [aws_lb.unreal_horde_internal_alb](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb) | resource |
 | [aws_lb_listener.unreal_horde_external_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.unreal_horde_external_alb_http_listener](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener) | resource |
 | [aws_lb_listener.unreal_horde_internal_alb_https_listener](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener) | resource |
+| [aws_lb_listener.unreal_horde_internal_alb_http_listener](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener) | resource |
 | [aws_lb_listener_rule.unreal_horde_external_alb_grpc_rule](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_listener_rule.unreal_horde_internal_alb_grpc_rule](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_listener_rule) | resource |
 | [aws_lb_target_group.unreal_horde_api_target_group_external](https://registry.terraform.io/providers/hashicorp/aws/5.69.0/docs/resources/lb_target_group) | resource |

--- a/modules/unreal/horde/alb.tf
+++ b/modules/unreal/horde/alb.tf
@@ -108,6 +108,26 @@ resource "aws_lb_listener_rule" "unreal_horde_external_alb_grpc_rule" {
   }
 }
 
+# External ALB listener forwards to HTTPS listener
+resource "aws_lb_listener" "unreal_horde_external_alb_http_listener" {
+  count             = var.create_external_alb ? 1 : 0
+  load_balancer_arn = aws_lb.unreal_horde_external_alb[0].arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      status_code = "HTTP_301"
+      protocol    = aws_lb_listener.unreal_horde_external_alb_https_listener[0].protocol
+      port        = aws_lb_listener.unreal_horde_external_alb_https_listener[0].port
+    }
+  }
+
+  tags = local.tags
+}
+
 ###########################
 # Internal Load Balancer
 ###########################
@@ -220,6 +240,26 @@ resource "aws_lb_listener_rule" "unreal_horde_internal_alb_grpc_rule" {
     target_group_arn = aws_lb_target_group.unreal_horde_grpc_target_group_internal[0].arn
     type             = "forward"
   }
+}
+
+# Internal ALB listener forwards to HTTPS listener
+resource "aws_lb_listener" "unreal_horde_internal_alb_http_listener" {
+  count             = var.create_internal_alb ? 1 : 0
+  load_balancer_arn = aws_lb.unreal_horde_internal_alb[0].arn
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type = "redirect"
+
+    redirect {
+      status_code = "HTTP_301"
+      protocol    = aws_lb_listener.unreal_horde_internal_alb_https_listener[0].protocol
+      port        = aws_lb_listener.unreal_horde_internal_alb_https_listener[0].port
+    }
+  }
+
+  tags = local.tags
 }
 
 ###########################

--- a/modules/unreal/horde/alb.tf
+++ b/modules/unreal/horde/alb.tf
@@ -120,7 +120,7 @@ resource "aws_lb_listener" "unreal_horde_external_alb_http_listener" {
 
     redirect {
       status_code = "HTTP_301"
-      protocol    = aws_lb_listener.unreal_horde_external_alb_https_listener[0].protocol
+      protocol    = "HTTPS"
       port        = aws_lb_listener.unreal_horde_external_alb_https_listener[0].port
     }
   }
@@ -254,7 +254,7 @@ resource "aws_lb_listener" "unreal_horde_internal_alb_http_listener" {
 
     redirect {
       status_code = "HTTP_301"
-      protocol    = aws_lb_listener.unreal_horde_internal_alb_https_listener[0].protocol
+      protocol    = "HTTPS"
       port        = aws_lb_listener.unreal_horde_internal_alb_https_listener[0].port
     }
   }
@@ -274,8 +274,8 @@ resource "random_string" "unreal_horde_alb_access_logs_bucket_suffix" {
 }
 
 resource "aws_s3_bucket" "unreal_horde_alb_access_logs_bucket" {
-  count  = var.enable_unreal_horde_alb_access_logs && var.unreal_horde_alb_access_logs_bucket == null ? 1 : 0
-  bucket = "${local.name_prefix}-alb-access-logs-${random_string.unreal_horde_alb_access_logs_bucket_suffix[0].result}"
+  count         = var.enable_unreal_horde_alb_access_logs && var.unreal_horde_alb_access_logs_bucket == null ? 1 : 0
+  bucket        = "${local.name_prefix}-alb-access-logs-${random_string.unreal_horde_alb_access_logs_bucket_suffix[0].result}"
   force_destroy = true
 
   #checkov:skip=CKV_AWS_21: Versioning not necessary for access logs


### PR DESCRIPTION
## Summary

### Changes

Adds listeners to the external and internal ALBs to permanently forward http traffic to https.

### User experience

Before: browsing to `http://horde.whatever.tld` in some browsers will just sit and spin forever because ALB black-holes traffic by default.
After: browsing to the same url will quickly redirect to the HTTPS secured URL.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No, this is purely an additive change.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.