### PR TITLE
Feature: Adding ECS Agents on TeamCity Server Startup

### DIFF
--- a/modules/teamcity/README.md
+++ b/modules/teamcity/README.md
@@ -21,15 +21,15 @@ For example configurations, please see the [examples](https://github.com/aws-gam
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.89.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | 3.5.1 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | 5.97.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | 3.7.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.89.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.97.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.7.1 |
 
 ## Modules
 
@@ -39,52 +39,72 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_log_group.teamcity_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/cloudwatch_log_group) | resource |
-| [aws_db_subnet_group.teamcity_db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/db_subnet_group) | resource |
-| [aws_ecs_cluster.teamcity_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ecs_cluster) | resource |
-| [aws_ecs_service.teamcity](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ecs_service) | resource |
-| [aws_ecs_task_definition.teamcity_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/ecs_task_definition) | resource |
-| [aws_efs_access_point.teamcity_efs_data_access_point](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/efs_access_point) | resource |
-| [aws_efs_file_system.teamcity_efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/efs_file_system) | resource |
-| [aws_efs_mount_target.teamcity_efs_mount_target](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/efs_mount_target) | resource |
-| [aws_iam_policy.teamcity_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_policy) | resource |
-| [aws_iam_role.teamcity_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role) | resource |
-| [aws_iam_role.teamcity_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/iam_role) | resource |
-| [aws_lb.teamcity_external_lb](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb) | resource |
-| [aws_lb_listener.teamcity_listener](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_listener) | resource |
-| [aws_lb_target_group.teamcity_target_group](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/lb_target_group) | resource |
-| [aws_rds_cluster.teamcity_db_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/rds_cluster) | resource |
-| [aws_rds_cluster_instance.teamcity_db_cluster_instance](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/rds_cluster_instance) | resource |
-| [aws_s3_bucket.teamcity_alb_access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket) | resource |
-| [aws_s3_bucket_lifecycle_configuration.access_logs_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
-| [aws_s3_bucket_policy.alb_access_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket_policy) | resource |
-| [aws_s3_bucket_public_access_block.access_logs_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/s3_bucket_public_access_block) | resource |
-| [aws_security_group.teamcity_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
-| [aws_security_group.teamcity_db_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
-| [aws_security_group.teamcity_efs_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
-| [aws_security_group.teamcity_service_sg](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/security_group) | resource |
-| [aws_vpc_security_group_egress_rule.alb_outbound_service](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_egress_rule.service_outbound_internet](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_egress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.service_db](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.service_efs](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [aws_vpc_security_group_ingress_rule.service_inbound_alb](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [random_string.teamcity_alb_access_logs_bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/3.5.1/docs/resources/string) | resource |
-| [aws_ecs_cluster.teamcity_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/ecs_cluster) | data source |
-| [aws_efs_file_system.efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/efs_file_system) | data source |
-| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/elb_service_account) | data source |
-| [aws_iam_policy_document.access_logs_bucket_alb_write](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.teamcity_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.89.0/docs/data-sources/region) | data source |
+| [aws_cloudwatch_log_group.teamcity_agent](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_cloudwatch_log_group.teamcity_log_group](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/cloudwatch_log_group) | resource |
+| [aws_db_subnet_group.teamcity_db_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/db_subnet_group) | resource |
+| [aws_ecs_cluster.teamcity_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_service.teamcity](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/ecs_service) | resource |
+| [aws_ecs_service.teamcity_agent](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.teamcity_agent](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/ecs_task_definition) | resource |
+| [aws_ecs_task_definition.teamcity_task_definition](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/ecs_task_definition) | resource |
+| [aws_efs_access_point.teamcity_efs_data_access_point](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/efs_access_point) | resource |
+| [aws_efs_file_system.teamcity_efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/efs_file_system) | resource |
+| [aws_efs_mount_target.teamcity_efs_mount_target](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/efs_mount_target) | resource |
+| [aws_iam_policy.teamcity_agent_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.teamcity_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.teamcity_execution_database_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_policy) | resource |
+| [aws_iam_role.teamcity_agent_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.teamcity_agent_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.teamcity_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role) | resource |
+| [aws_iam_role.teamcity_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.teamcity_agent_default_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.teamcity_agent_task_execution_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.teamcity_default_role](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.teamcity_task_execution_database_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.teamcity_task_execution_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lb.teamcity_external_lb](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/lb) | resource |
+| [aws_lb_listener.teamcity_listener](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/lb_listener) | resource |
+| [aws_lb_target_group.teamcity_target_group](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/lb_target_group) | resource |
+| [aws_rds_cluster.teamcity_db_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/rds_cluster) | resource |
+| [aws_rds_cluster_instance.teamcity_db_cluster_instance](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/rds_cluster_instance) | resource |
+| [aws_s3_bucket.teamcity_alb_access_logs_bucket](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_lifecycle_configuration.access_logs_bucket_lifecycle_configuration](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_policy.alb_access_logs_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/s3_bucket_policy) | resource |
+| [aws_s3_bucket_public_access_block.access_logs_bucket_public_block](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_security_group.teamcity_agent_sg](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/security_group) | resource |
+| [aws_security_group.teamcity_alb_sg](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/security_group) | resource |
+| [aws_security_group.teamcity_db_sg](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/security_group) | resource |
+| [aws_security_group.teamcity_efs_sg](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/security_group) | resource |
+| [aws_security_group.teamcity_service_sg](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/security_group) | resource |
+| [aws_service_discovery_http_namespace.teamcity](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/service_discovery_http_namespace) | resource |
+| [aws_vpc_security_group_egress_rule.alb_outbound_service](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.service_outbound_internet](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_egress_rule.teamcity_agent_outbound](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.service_db](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.service_efs](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.service_inbound_alb](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.teamcity_agent_inbound](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [random_string.teamcity_alb_access_logs_bucket_suffix](https://registry.terraform.io/providers/hashicorp/random/3.7.1/docs/resources/string) | resource |
+| [aws_ecs_cluster.teamcity_cluster](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/ecs_cluster) | data source |
+| [aws_efs_file_system.efs_file_system](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/efs_file_system) | data source |
+| [aws_elb_service_account.main](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/elb_service_account) | data source |
+| [aws_iam_policy_document.access_logs_bucket_alb_write](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_tasks_trust_relationship](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.teamcity_agent_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.teamcity_default_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.teamcity_execution_database_policy](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/5.97.0/docs/data-sources/region) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_agent_log_group_retention_in_days"></a> [agent\_log\_group\_retention\_in\_days](#input\_agent\_log\_group\_retention\_in\_days) | n/a | `number` | `7` | no |
 | <a name="input_alb_certificate_arn"></a> [alb\_certificate\_arn](#input\_alb\_certificate\_arn) | The ARN of the SSL certificate to use for the ALB | `string` | `null` | no |
 | <a name="input_alb_subnets"></a> [alb\_subnets](#input\_alb\_subnets) | The subnets in which the ALB will be deployed | `list(string)` | `[]` | no |
 | <a name="input_aurora_instance_count"></a> [aurora\_instance\_count](#input\_aurora\_instance\_count) | Number of instances to provision for the Aurora cluster | `number` | `2` | no |
 | <a name="input_aurora_skip_final_snapshot"></a> [aurora\_skip\_final\_snapshot](#input\_aurora\_skip\_final\_snapshot) | Flag for whether a final snapshot should be created when the cluster is destroyed. | `bool` | `true` | no |
+| <a name="input_build_farm_config"></a> [build\_farm\_config](#input\_build\_farm\_config) | n/a | <pre>map(object({<br>    image         = string<br>    desired_count = number<br>    cpu           = number<br>    memory        = number<br>  }))</pre> | `{}` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the ECS cluster to deploy TeamCity to. | `string` | `null` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | The number of CPU units to allocate to the TeamCity server container | `number` | `1024` | no |
 | <a name="input_container_memory"></a> [container\_memory](#input\_container\_memory) | The number of MB of memory to allocate to the TeamCity server container | `number` | `4096` | no |
@@ -104,7 +124,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The current environment (e.g. dev, prod, etc.) | `string` | `"dev"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name applied to resources in the TeamCity module | `string` | `"teamcity"` | no |
 | <a name="input_service_subnets"></a> [service\_subnets](#input\_service\_subnets) | The subnets in which the TeamCity server service will be deployed | `list(string)` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br/>  "iac-management": "CGD-Toolkit",<br/>  "iac-module": "TeamCity",<br/>  "iac-provider": "Terraform"<br/>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br>  "iac-management": "CGD-Toolkit",<br>  "iac-module": "TeamCity",<br>  "iac-provider": "Terraform"<br>}</pre> | no |
 | <a name="input_teamcity_alb_access_logs_bucket"></a> [teamcity\_alb\_access\_logs\_bucket](#input\_teamcity\_alb\_access\_logs\_bucket) | ID of the S3 bucket for TeamCity ALB access log storage. If access logging is enabled and this is null the module creates a bucket. | `string` | `null` | no |
 | <a name="input_teamcity_alb_access_logs_prefix"></a> [teamcity\_alb\_access\_logs\_prefix](#input\_teamcity\_alb\_access\_logs\_prefix) | Log prefix for TeamCity ALB access logs. If null the project prefix and module name are used. | `string` | `null` | no |
 | <a name="input_teamcity_cloudwatch_log_retention_in_days"></a> [teamcity\_cloudwatch\_log\_retention\_in\_days](#input\_teamcity\_cloudwatch\_log\_retention\_in\_days) | The log retention in days of the cloudwatch log group for TeamCity. | `string` | `365` | no |
@@ -118,4 +138,6 @@ No modules.
 |------|-------------|
 | <a name="output_external_alb_dns_name"></a> [external\_alb\_dns\_name](#output\_external\_alb\_dns\_name) | DNS endpoint of Application Load Balancer (ALB) |
 | <a name="output_external_alb_zone_id"></a> [external\_alb\_zone\_id](#output\_external\_alb\_zone\_id) | Zone ID for internet facing load balancer |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The default security group of your Teamcity service. |
+| <a name="output_teamcity_cluster_id"></a> [teamcity\_cluster\_id](#output\_teamcity\_cluster\_id) | The ID of the ECS cluster |
 <!-- END_TF_DOCS -->

--- a/modules/teamcity/agents.tf
+++ b/modules/teamcity/agents.tf
@@ -1,0 +1,184 @@
+#################################
+###### ECS TASK AND SERVICE #####
+#################################
+
+resource "aws_ecs_task_definition" "teamcity_agent" {
+  # create a task for each build agent config in the build_farm_config variable
+  #checkov:skip=CKV_AWS_336: EFS is not necessary for TeamCity Agents
+
+  for_each = var.build_farm_config
+
+  family                   = each.key
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = each.value.cpu
+  memory                   = each.value.memory
+  execution_role_arn       = aws_iam_role.teamcity_agent_task_execution_role.arn
+  task_role_arn            = aws_iam_role.teamcity_agent_default_role.arn
+  container_definitions = jsonencode([
+    {
+      name      = "teamcity-agent"
+      image     = each.value.image
+      cpu       = each.value.cpu
+      memory    = each.value.memory
+      essential = true
+      environment = [
+        {
+          name  = "SERVER_URL"
+          value = "http://teamcity-server.teamcity-namespace:8111"
+        },
+        {
+          name  = "AGENT_NAME"
+          value = "${each.key}-agent"
+        },
+
+      ]
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.teamcity_agent.name
+          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-stream-prefix" = "[AGENT - ${each.key}]"
+        }
+      }
+    }
+  ])
+}
+
+resource "aws_ecs_service" "teamcity_agent" {
+  for_each = var.build_farm_config
+
+  name = each.key
+  cluster = (var.cluster_name != null ? data.aws_ecs_cluster.teamcity_cluster[0].arn :
+  aws_ecs_cluster.teamcity_cluster[0].arn)
+  task_definition = aws_ecs_task_definition.teamcity_agent[each.key].arn
+  desired_count   = each.value.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets         = var.service_subnets
+    security_groups = [aws_security_group.teamcity_agent_sg.id]
+  }
+
+  enable_execute_command = var.debug
+
+  service_connect_configuration {
+    enabled   = true
+    namespace = aws_service_discovery_http_namespace.teamcity[0].arn
+
+    log_configuration {
+      log_driver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.teamcity_agent.name
+        "awslogs-region"        = data.aws_region.current.name
+        "awslogs-stream-prefix" = "[AGENT - ${each.key}]"
+      }
+    }
+  }
+
+  depends_on = [
+    aws_ecs_service.teamcity
+  ]
+}
+
+#################################
+### SECURITY GROUPS FOR AGENTS ##
+#################################
+
+# SECURITY GROUP FOR TEAMCITY AGENTS
+resource "aws_security_group" "teamcity_agent_sg" {
+  name        = "teamcity_agent_sg"
+  description = "Security Group for Teamcity Agents"
+  vpc_id      = var.vpc_id
+}
+
+# SECURITY GROUP EGRESS FOR TEAMCITY AGENTS
+resource "aws_vpc_security_group_egress_rule" "teamcity_agent_outbound" {
+  security_group_id = aws_security_group.teamcity_agent_sg.id
+  description       = "Allow outbound to anywhere"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+# SECURITY GROUP FOR TEAMCITY SERVICE TO ALLOW TEAMCITY AGENT
+resource "aws_vpc_security_group_ingress_rule" "teamcity_agent_inbound" {
+  security_group_id            = aws_security_group.teamcity_service_sg.id
+  description                  = "Allow inbound traffic from Teamcity Agent"
+  referenced_security_group_id = aws_security_group.teamcity_agent_sg.id
+  from_port                    = var.container_port
+  to_port                      = var.container_port
+  ip_protocol                  = "TCP"
+}
+
+#################################
+#### IAM ROLES AND POLICIES #####
+#################################
+
+data "aws_iam_policy_document" "teamcity_agent_default_policy" {
+  #checkov:skip=CKV_AWS_111: resources need IAM write permissions
+  #checkov:skip=CKV_AWS_356: resources need IAM write permissions
+  statement {
+    sid    = "ECSExec"
+    effect = "Allow"
+    actions = [
+      "ssmmessages:OpenDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:CreateControlChannel",
+    ]
+    resources = [
+      "*"
+    ]
+  }
+
+  statement {
+    sid       = "ServiceDiscovery"
+    effect    = "Allow"
+    actions   = ["servicediscovery:DiscoverInstances"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "logs"
+    effect    = "Allow"
+    actions   = ["logs:CreateLogGroup"]
+    resources = ["*"]
+  }
+}
+
+
+resource "aws_iam_policy" "teamcity_agent_default_policy" {
+  name        = "teamcity-agent-default-policy"
+  description = "Default policy for Teamcity Agents permissions"
+  policy      = data.aws_iam_policy_document.teamcity_agent_default_policy.json
+}
+
+resource "aws_iam_role" "teamcity_agent_default_role" {
+  name               = "teamcity-agent-default-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
+
+}
+
+resource "aws_iam_role_policy_attachment" "teamcity_agent_default_role_policy_attachment" {
+  role       = aws_iam_role.teamcity_agent_default_role.name
+  policy_arn = aws_iam_policy.teamcity_agent_default_policy.arn
+}
+
+resource "aws_iam_role" "teamcity_agent_task_execution_role" {
+  name               = "teamcity-agent-task-execution-role"
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
+}
+
+resource "aws_iam_role_policy_attachment" "teamcity_agent_task_execution_default_policy" {
+  #checkov:skip=CKV_AWS_338: does not need CW logs for a year
+  #checkov:skip=CKV_AWS_158: CW Log Group does not need to be encrypted
+  role       = aws_iam_role.teamcity_agent_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_cloudwatch_log_group" "teamcity_agent" {
+  #checkov:skip=CKV_AWS_158: CW Log Group does not need to be encrypted
+  #checkov:skip=CKV_AWS_338: CW Log Group does not need to be retained for 1 year
+  name              = "/ecs/teamcity-agent"
+  retention_in_days = var.agent_log_group_retention_in_days
+}

--- a/modules/teamcity/examples/simple/main.tf
+++ b/modules/teamcity/examples/simple/main.tf
@@ -4,4 +4,13 @@ module "teamcity" {
   service_subnets     = aws_subnet.private_subnets[*].id
   alb_subnets         = aws_subnet.public_subnets[*].id
   alb_certificate_arn = aws_acm_certificate.teamcity.arn
+
+  build_farm_config = {
+    "teamcity-simple" = {
+      image         = "jetbrains/teamcity-agent"
+      cpu           = 256
+      memory        = 256
+      desired_count = 3
+    }
+  }
 }

--- a/modules/teamcity/examples/simple/versions.tf
+++ b/modules/teamcity/examples/simple/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.89.0"
+      version = "5.97.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.5.1"
+      version = "3.7.1"
     }
   }
 }

--- a/modules/teamcity/outputs.tf
+++ b/modules/teamcity/outputs.tf
@@ -7,3 +7,13 @@ output "external_alb_zone_id" {
   value       = var.create_external_alb ? aws_lb.teamcity_external_lb[0].zone_id : null
   description = "Zone ID for internet facing load balancer"
 }
+
+output "security_group_id" {
+  value       = aws_security_group.teamcity_service_sg.id
+  description = "The default security group of your Teamcity service."
+}
+
+output "teamcity_cluster_id" {
+  value       = aws_ecs_cluster.teamcity_cluster[0].id
+  description = "The ID of the ECS cluster"
+}

--- a/modules/teamcity/variables.tf
+++ b/modules/teamcity/variables.tf
@@ -225,3 +225,22 @@ variable "aurora_instance_count" {
   description = "Number of instances to provision for the Aurora cluster"
   default     = 2
 }
+
+##########################################
+### Build Farm Configuration Variables ###
+##########################################
+
+variable "build_farm_config" {
+  type = map(object({
+    image         = string
+    desired_count = number
+    cpu           = number
+    memory        = number
+  }))
+  default = {}
+}
+
+variable "agent_log_group_retention_in_days" {
+  type    = number
+  default = 7
+}

--- a/modules/teamcity/versions.tf
+++ b/modules/teamcity/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.89.0"
+      version = "5.97.0"
     }
     random = {
       source  = "hashicorp/random"
-      version = "3.5.1"
+      version = "3.7.1"
     }
   }
 }


### PR DESCRIPTION
closes #635

## Summary

This PR adds the functionality of having TeamCity agents available in the TeamCity server on startup.

### Changes

- Adds `agents.tf` to the TeamCity module.
- `main.tf` will also have configurations for ECS Service Connect, which is being used for the communication between the TeamCity server and the agent(s).
- cleaned up the IAM policy document and attachments in `main.tf`.

### User experience

Users will optionally be able to deploy a TeamCity agent to the TeamCity server on startup, and can configure the following in the `build_farm_config` variable:

- the agent image
- desired count
- cpu and memory allocation for each task

The user can also create different types of agents within the `buiild_farm_config` in case different images need to be used.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ X ] I have performed a self-review of this change
* [ X ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

no

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.