### PR TITLE
chore(deps): run pre-commit autoupdate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/gitleaks/gitleaks
-    rev: "v8.23.1"
+    rev: "v8.27.2"
     hooks:
       - id: gitleaks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: detect-private-key
@@ -14,12 +14,12 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/bridgecrewio/checkov
-    rev: "3.2.201"
+    rev: "3.2.445"
     hooks:
       - id: checkov
         args: ["--config-file", ".config/.checkov.yml"]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: "v1.89.1"
+    rev: "v1.99.4"
     hooks:
       - id: terraform_docs
         args:


### PR DESCRIPTION
## Summary

Prompted by pre-commit-hooks v4.6.0 emitting a deprecation warning.

### Changes

> Ran `pre-commit autoupdate` to update pre-commit checks.

### User experience

> None, except pre-commit checks will stop emitting warnings.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.