### PR TITLE
fix: Update SG reference in P4 FSxN Example

### DIFF
--- a/modules/perforce/examples/p4-server-fsxn/main.tf
+++ b/modules/perforce/examples/p4-server-fsxn/main.tf
@@ -16,7 +16,7 @@ resource "aws_vpc_security_group_ingress_rule" "fsxn_inbound_p4_server" {
   ip_protocol                  = "-1"
   description                  = "Allows all inbound access from the VPC."
   security_group_id            = aws_security_group.fsx_ontap_file_system_sg.id
-  referenced_security_group_id = module.perforce.security_group_id
+  referenced_security_group_id = module.perforce.p4_server_security_group_id
   lifecycle {
     create_before_destroy = true
   }


### PR DESCRIPTION
**closes issue #639 **

## Summary

Updated reference for Security Group in Perforce FSxN Example Main.tf to correctly point to p4_server_security_group_id.

### Changes

> Please provide a summary of what's being changed
```hcl
resource "aws_vpc_security_group_ingress_rule" "fsxn_inbound_p4_server" {
  ip_protocol                  = "-1"
  description                  = "Allows all inbound access from the VPC."
  security_group_id            = aws_security_group.fsx_ontap_file_system_sg.id
  referenced_security_group_id = module.perforce.p4_server_security_group_id
  lifecycle {
    create_before_destroy = true
  }
}
```
### User experience

> Please share what the user experience looks like before and after this change
Before: User gets an error when running Terraform Plan, Test, or Apply

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented


## Terraform Test Output
```hcl
awsbilal@b0be837706b2 perforce % terraform test                        
tests/01_create_resources_complete.tftest.hcl... in progress
  run "setup"... pass
  run "unit_test"... pass
tests/01_create_resources_complete.tftest.hcl... tearing down
tests/01_create_resources_complete.tftest.hcl... pass
tests/02_p4_server_fsxn.tftest.hcl... in progress
  run "setup"... pass
  run "unit_test"... pass
tests/02_p4_server_fsxn.tftest.hcl... tearing down
tests/02_p4_server_fsxn.tftest.hcl... pass

Success! 4 passed, 0 failed.
```
<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.