### PR TITLE
fix: Fixes typo in code block in samples DDC readme

### DIFF
--- a/samples/unreal-cloud-ddc-single-region/README.md
+++ b/samples/unreal-cloud-ddc-single-region/README.md
@@ -11,7 +11,7 @@ The [Unreal Cloud DDC Inter Cluster module](../modules/unreal/unreal-cloud-ddc-i
 ```json
 {
   "username":"GITHUB-USER-NAME-PLACEHOLDER",
-  "accessToken":"GITHUB-ACCESS-TOKEN-PLACEHOLDER"
+  "access-token":"GITHUB-ACCESS-TOKEN-PLACEHOLDER"
 }
 ```
 


### PR DESCRIPTION
**Issue number:** 628

## Summary 

>The Cloud DDC within the Samples directory contained a command line typo

### Changes

> Used the Cloud DDC Module to cross reference the command to create the secret and verified the code worked by running it myself

  "accessToken":"GITHUB-ACCESS-TOKEN-PLACEHOLDER" > Wrong
VS
  "access-token":"GITHUB-ACCESS-TOKEN-PLACEHOLDER" > Right

### User experience

>This will create a unified experience for the user rather than 2 different commands for the same purpose

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.