### PR TITLE
feat(horde): allow users to bring their own horde-server images

### DIFF
--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -127,7 +127,7 @@ No modules.
 | <a name="input_admin_claim_type"></a> [admin\_claim\_type](#input\_admin\_claim\_type) | The claim type for administrators. | `string` | `null` | no |
 | <a name="input_admin_claim_value"></a> [admin\_claim\_value](#input\_admin\_claim\_value) | The claim value for administrators. | `string` | `null` | no |
 | <a name="input_agents"></a> [agents](#input\_agents) | Configures autoscaling groups to be used as build agents by Unreal Engine Horde. | <pre>map(object({<br/>    ami           = string<br/>    instance_type = string<br/>    block_device_mappings = list(<br/>      object({<br/>        device_name = string<br/>        ebs = object({<br/>          volume_size = number<br/>        })<br/>      })<br/>    )<br/>    min_size = optional(number, 0)<br/>    max_size = optional(number, 1)<br/>  }))</pre> | `{}` | no |
-| <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | The authentication method for the Horde server. | `string` | `"Anonymous"` | no |
+| <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | The authentication method for the Horde server. | `string` | `null` | no |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | The TLS certificate ARN for the Unreal Horde load balancer. | `string` | n/a | yes |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster to deploy the Unreal Horde into. Defaults to null and a cluster will be created. | `string` | `null` | no |
 | <a name="input_container_api_port"></a> [container\_api\_port](#input\_container\_api\_port) | The container port for the Unreal Horde web server. | `number` | `5000` | no |

--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -161,6 +161,7 @@ No modules.
 | <a name="input_existing_security_groups"></a> [existing\_security\_groups](#input\_existing\_security\_groups) | A list of existing security group IDs to attach to the Unreal Horde load balancer. | `list(string)` | `[]` | no |
 | <a name="input_fully_qualified_domain_name"></a> [fully\_qualified\_domain\_name](#input\_fully\_qualified\_domain\_name) | The fully qualified domain name where your Unreal Engine Horde server will be available. This agents will use this to enroll. | `string` | n/a | yes |
 | <a name="input_github_credentials_secret_arn"></a> [github\_credentials\_secret\_arn](#input\_github\_credentials\_secret\_arn) | A secret containing the Github username and password with permissions to the EpicGames organization. | `string` | n/a | yes |
+| <a name="input_image"></a> [image](#input\_image) | The Horde Server image to use in the ECS service. | `string` | `"ghcr.io/epicgames/horde-server:latest-bundled"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name attached to Unreal Engine Horde module resources. | `string` | `"unreal-horde"` | no |
 | <a name="input_oidc_audience"></a> [oidc\_audience](#input\_oidc\_audience) | The audience used for validating externally issued tokens. | `string` | `null` | no |
 | <a name="input_oidc_authority"></a> [oidc\_authority](#input\_oidc\_authority) | The authority for the OIDC authentication provider used. | `string` | `null` | no |

--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -160,7 +160,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The current environment (e.g. Development, Staging, Production, etc.). This will tag ressources and set ASPNETCORE\_ENVIRONMENT variable. | `string` | `"Development"` | no |
 | <a name="input_existing_security_groups"></a> [existing\_security\_groups](#input\_existing\_security\_groups) | A list of existing security group IDs to attach to the Unreal Horde load balancer. | `list(string)` | `[]` | no |
 | <a name="input_fully_qualified_domain_name"></a> [fully\_qualified\_domain\_name](#input\_fully\_qualified\_domain\_name) | The fully qualified domain name where your Unreal Engine Horde server will be available. This agents will use this to enroll. | `string` | n/a | yes |
-| <a name="input_github_credentials_secret_arn"></a> [github\_credentials\_secret\_arn](#input\_github\_credentials\_secret\_arn) | A secret containing the Github username and password with permissions to the EpicGames organization. | `string` | n/a | yes |
+| <a name="input_github_credentials_secret_arn"></a> [github\_credentials\_secret\_arn](#input\_github\_credentials\_secret\_arn) | A secret containing the Github username and password with permissions to the EpicGames organization. | `string` | `null` | no |
 | <a name="input_image"></a> [image](#input\_image) | The Horde Server image to use in the ECS service. | `string` | `"ghcr.io/epicgames/horde-server:latest-bundled"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name attached to Unreal Engine Horde module resources. | `string` | `"unreal-horde"` | no |
 | <a name="input_oidc_audience"></a> [oidc\_audience](#input\_oidc\_audience) | The audience used for validating externally issued tokens. | `string` | `null` | no |

--- a/modules/unreal/horde/ecs.tf
+++ b/modules/unreal/horde/ecs.tf
@@ -39,9 +39,9 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
     {
       name  = var.container_name
       image = var.image
-      repositoryCredentials = {
+      repositoryCredentials = var.github_credentials_secret_arn != null ? {
         "credentialsParameter" : var.github_credentials_secret_arn
-      }
+      } : null
       cpu       = var.container_cpu
       memory    = var.container_memory
       essential = true

--- a/modules/unreal/horde/ecs.tf
+++ b/modules/unreal/horde/ecs.tf
@@ -38,7 +38,7 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
   container_definitions = jsonencode([
     {
       name  = var.container_name
-      image = local.image
+      image = var.image
       repositoryCredentials = {
         "credentialsParameter" : var.github_credentials_secret_arn
       }

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -64,6 +64,7 @@ resource "aws_iam_role" "unreal_horde_default_role" {
 }
 
 data "aws_iam_policy_document" "unreal_horde_secrets_manager_policy" {
+  count = var.github_credentials_secret_arn != null ? 1 : 0
   statement {
     effect = "Allow"
     actions = [
@@ -76,14 +77,17 @@ data "aws_iam_policy_document" "unreal_horde_secrets_manager_policy" {
 }
 
 resource "aws_iam_policy" "unreal_horde_secrets_manager_policy" {
+  count       = var.github_credentials_secret_arn != null ? 1 : 0
   name        = "${var.project_prefix}-unreal-horde-secrets-manager-policy"
   description = "Policy granting permissions for Unreal Horde task execution role to access SSM."
-  policy      = data.aws_iam_policy_document.unreal_horde_secrets_manager_policy.json
+  policy      = data.aws_iam_policy_document.unreal_horde_secrets_manager_policy[0].json
 }
 
 resource "aws_iam_role" "unreal_horde_task_execution_role" {
   name = "${var.project_prefix}-unreal_horde-task-execution-role"
 
-  assume_role_policy  = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
-  managed_policy_arns = ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy", aws_iam_policy.unreal_horde_secrets_manager_policy.arn]
+  assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
+  managed_policy_arns = concat([
+    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+  ], [for policy in aws_iam_policy.unreal_horde_secrets_manager_policy : policy.arn])
 }

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -8,7 +8,6 @@ resource "random_string" "unreal_horde" {
 data "aws_region" "current" {}
 
 locals {
-  image       = "ghcr.io/epicgames/horde-server:latest-bundled"
   name_prefix = "${var.project_prefix}-${var.name}"
   tags = merge(var.tags, {
     "environment" = var.environment

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -54,6 +54,12 @@ variable "vpc_id" {
 # ECS
 ########################################
 
+variable "image" {
+  type        = string
+  description = "The Horde Server image to use in the ECS service."
+  default     = "ghcr.io/epicgames/horde-server:latest-bundled"
+}
+
 variable "cluster_name" {
   type        = string
   description = "The name of the cluster to deploy the Unreal Horde into. Defaults to null and a cluster will be created."

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -225,9 +225,9 @@ variable "github_credentials_secret_arn" {
 variable "auth_method" {
   type        = string
   description = "The authentication method for the Horde server."
-  default     = "Anonymous"
+  default     = null
   validation {
-    condition     = contains(["Anonymous", "Okta", "OpenIdConnect", "Horde"], var.auth_method)
+    condition     = var.auth_method == null || contains(["Anonymous", "Okta", "OpenIdConnect", "Horde"], var.auth_method)
     error_message = "Invalid authentication method. Must be one of: Anonymous, Okta, OpenIdConnect, Horde"
   }
 }
@@ -237,7 +237,7 @@ variable "oidc_authority" {
   description = "The authority for the OIDC authentication provider used."
   default     = null
   validation {
-    condition     = contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_authority != null : var.oidc_authority == null
+    condition     = var.auth_method != null && contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_authority != null : var.oidc_authority == null
     error_message = "An OIDC authority must be provided for Okta and OpenIdConnect authentication methods."
   }
 }
@@ -247,7 +247,7 @@ variable "oidc_audience" {
   description = "The audience used for validating externally issued tokens."
   default     = null
   validation {
-    condition     = contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_audience != null : var.oidc_audience == null
+    condition     = var.auth_method != null && contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_audience != null : var.oidc_audience == null
     error_message = "An OIDC audience must be provided for Okta and OpenIdConnect authentication methods."
   }
 }
@@ -257,7 +257,7 @@ variable "oidc_client_id" {
   description = "The client ID used for authenticating with the OIDC provider."
   default     = null
   validation {
-    condition     = contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_client_id != null : var.oidc_client_id == null
+    condition     = var.auth_method != null && contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_client_id != null : var.oidc_client_id == null
     error_message = "An OIDC client ID must be provided for Okta and OpenIdConnect authentication methods."
   }
 }
@@ -267,7 +267,7 @@ variable "oidc_client_secret" {
   description = "The client secret used for authenticating with the OIDC provider."
   default     = null
   validation {
-    condition     = contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_client_secret != null : var.oidc_client_secret == null
+    condition     = var.auth_method != null && contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_client_secret != null : var.oidc_client_secret == null
     error_message = "An OIDC client secret must be provided for Okta and OpenIdConnect authentication methods."
   }
 }
@@ -277,7 +277,7 @@ variable "oidc_signin_redirect" {
   description = "The sign-in redirect URL for the OIDC provider."
   default     = null
   validation {
-    condition     = contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_signin_redirect != null : var.oidc_signin_redirect == null
+    condition     = var.auth_method != null && contains(["Okta", "OpenIdConnect"], var.auth_method) ? var.oidc_signin_redirect != null : var.oidc_signin_redirect == null
     error_message = "An OIDC sign-in redirect URL must be provided for Okta and OpenIdConnect authentication methods."
   }
 }

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -215,6 +215,7 @@ variable "create_unreal_horde_default_policy" {
 variable "github_credentials_secret_arn" {
   type        = string
   description = "A secret containing the Github username and password with permissions to the EpicGames organization."
+  default     = null
 }
 
 ######################


### PR DESCRIPTION
## Summary

This change allows users to bring their own Horde Server images, most frequently built from custom engine builds with the Engine/Source/Programs/Horde/BuildHorde.xml BuildGraph, which allows building the image from source and pushing it to ECR or similar.

### Changes

* Expose `image` as a variable to the outside world
* Make `github_credentials_secret_arn` optional, since it isn't needed for ECR images
* Make authentication variables optional, since images with custom config files won't need them.

### User experience

No changes to the existing experience.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [x] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
Nope, just a new feature!
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.