### PR TITLE
fix: Minor Perforce module copy/paste naming resolution

### DIFF
--- a/modules/perforce/modules/p4-server/main.tf
+++ b/modules/perforce/modules/p4-server/main.tf
@@ -2,7 +2,7 @@
 # Perforce P4 Server Super User
 ##########################################
 resource "awscc_secretsmanager_secret" "super_user_password" {
-  count       = var.super_user_username_secret_arn == null ? 1 : 0
+  count         = var.super_user_password_secret_arn == null ? 1 : 0
   name        = "${local.name_prefix}-SuperUserPassword"
   description = "The password for the created P4 Server super user."
   generate_secret_string = {
@@ -13,7 +13,7 @@ resource "awscc_secretsmanager_secret" "super_user_password" {
 }
 
 resource "awscc_secretsmanager_secret" "super_user_username" {
-  count         = var.super_user_password_secret_arn == null ? 1 : 0
+  count       = var.super_user_username_secret_arn == null ? 1 : 0
   name          = "${local.name_prefix}-SuperUserUsername"
   description   = "The username for the created P4 Server super user."
   secret_string = "perforce"
@@ -70,8 +70,8 @@ locals {
 }
 
 locals {
-  username_secret = var.super_user_password_secret_arn == null ? awscc_secretsmanager_secret.super_user_username[0].secret_id : var.super_user_password_secret_arn
-  password_secret = var.super_user_username_secret_arn == null ? awscc_secretsmanager_secret.super_user_password[0].secret_id : var.super_user_username_secret_arn
+  username_secret = var.super_user_username_secret_arn == null ? awscc_secretsmanager_secret.super_user_username[0].secret_id : var.super_user_username_secret_arn
+  password_secret = var.super_user_password_secret_arn == null ? awscc_secretsmanager_secret.super_user_password[0].secret_id : var.super_user_password_secret_arn
 }
 resource "aws_instance" "server_instance" {
   ami           = data.aws_ami.existing_server_ami.id

--- a/modules/perforce/modules/p4-server/outputs.tf
+++ b/modules/perforce/modules/p4-server/outputs.tf
@@ -17,14 +17,14 @@ output "super_user_password_secret_arn" {
   value = (var.super_user_password_secret_arn == null ?
     awscc_secretsmanager_secret.super_user_password[0].secret_id :
   var.super_user_password_secret_arn)
-  description = "The ARN of the AWS Secrets Manager secret holding your P4 Server super user's username."
+  description = "The ARN of the AWS Secrets Manager secret holding your P4 Server super user's password."
 }
 
 output "super_user_username_secret_arn" {
   value = (var.super_user_username_secret_arn == null ?
     awscc_secretsmanager_secret.super_user_username[0].secret_id :
   var.super_user_username_secret_arn)
-  description = "The ARN of the AWS Secrets Manager secret holding your P4 Server super user's password."
+  description = "The ARN of the AWS Secrets Manager secret holding your P4 Server super user's username."
 }
 
 output "instance_id" {

--- a/modules/perforce/modules/p4-server/variables.tf
+++ b/modules/perforce/modules/p4-server/variables.tf
@@ -234,13 +234,13 @@ variable "internal" {
 
 variable "super_user_password_secret_arn" {
   type        = string
-  description = "If you would like to manage your own super user credentials through AWS Secrets Manager provide the ARN for the super user's username here. Otherwise, the default of 'perforce' will be used."
+  description = "If you would like to manage your own super user credentials through AWS Secrets Manager provide the ARN for the super user's password here."
   default     = null
 }
 
 variable "super_user_username_secret_arn" {
   type        = string
-  description = "If you would like to manage your own super user credentials through AWS Secrets Manager provide the ARN for the super user's password here."
+  description = "If you would like to manage your own super user credentials through AWS Secrets Manager provide the ARN for the super user's username here. Otherwise, the default of 'perforce' will be used."
   default     = null
 }
 


### PR DESCRIPTION
**Issue number:**
Closes #644 
## Summary

### Changes

> Please provide a summary of what's being changed
This PR resolves small naming issues that occurred when consolidating the Perforce modules. The current functionality did not provide a bug as current terraform tests do not check for user supplied username/password. Instead it defaults to assume that a user will use the username/password created for the users via secrets manager.



### User experience

> Please share what the user experience looks like before and after this change

Identical as before, just a minor naming fix.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ x] I have performed a self-review of this change
* [x ] Changes have been tested
* [x ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.