### PR TITLE
fix(perforce): fix typo in generating p4 auth service url

### DIFF
--- a/modules/perforce/main.tf
+++ b/modules/perforce/main.tf
@@ -17,7 +17,7 @@ module "p4_server" {
       (
         var.create_route53_private_hosted_zone ?
         "auth.${aws_route53_zone.perforce_private_hosted_zone[0].name}" :
-        module.p4_auth.alb_dns_name
+        module.p4_auth[0].alb_dns_name
       ) :
       null
     )


### PR DESCRIPTION
## Summary
Fixes a typo causing the P4 module to fail if `p4_server_config.auth_service_url` is not provided and `create_route53_private_hosted_zone` is false.

### Changes

Because module.p4_server is an array now (`count = 0 ? 1`), it must be indexed when read.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No it's a fixing change.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.