### PR TITLE
fix: update perforce tf test to support branches on forks

### DIFF
--- a/.github/workflows/tf-test-on-comment-modules-perforce.yml
+++ b/.github/workflows/tf-test-on-comment-modules-perforce.yml
@@ -76,6 +76,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ steps.comment-branch.outputs.head_ref }}
+          repository: ${{ steps.comment-branch.outputs.head_repo }}
+          fetch-depth: 0
 
       # Use GitHub Action secret to assume existing AWS IAM Role using OIDC connection
       - name: Configure AWS credentials from AWS account


### PR DESCRIPTION

**Issue number:**
none, adhoc fix.

## Summary

### Changes

Fixed GitHub Actions workflow to properly handle PR branches from fork repositories by adding the `repository` parameter and `fetch-depth: 0` to the checkout action. This resolves the issue where the workflow was failing to fetch branches from forks with errors like "failed with exit code 1" when attempting to fetch from repositories like 'secretdimension:fix/p4'.

### User experience

**Before:**
- PRs from the main repository worked correctly
- PRs from fork repositories failed with git fetch errors
- Users contributing from forks couldn't run Terraform tests via comment commands

**After:**
- PRs from both main repository and forks work correctly
- All users can trigger Terraform tests via comment commands regardless of PR source
- Workflow consistently fetches the correct branch whether it's from the main repo or a fork
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
no
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.