### PR TITLE
fix(p4): Fix typo'ed output.shared_application_load_balancer_arn

### DIFF
--- a/modules/perforce/outputs.tf
+++ b/modules/perforce/outputs.tf
@@ -4,7 +4,7 @@ output "shared_network_load_balancer_arn" {
   description = "The ARN of the shared network load balancer."
 }
 output "shared_application_load_balancer_arn" {
-  value       = var.create_shared_application_load_balancer ? aws_lb.perforce[0].arn : null
+  value       = var.create_shared_application_load_balancer ? aws_lb.perforce_web_services[0].arn : null
   description = "The ARN of the shared application load balancer."
 }
 


### PR DESCRIPTION
## Summary

Currently output `shared_application_load_balancer_arn` refers to the nlb, not the alb. This fixes that.

### User experience

This allows users to disable nlb creation while continuing to use the alb.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
Potentially, if anyone was relying on the incorrect output behavior.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.