### PR TITLE
fix: allow PRs from forks to be used with the GH action

### DIFF
--- a/.github/workflows/tf-test-on-comment-modules-perforce.yml
+++ b/.github/workflows/tf-test-on-comment-modules-perforce.yml
@@ -53,6 +53,9 @@ jobs:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           status: pending
+          allowForks: true
+          targetUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          context: ${{ github.workflow }}
 
       # Comment on PR that the workflow is in progress
       - name: Comment on PR that the workflow is in progress
@@ -72,11 +75,12 @@ jobs:
             })
 
       # Checkout the PR branch
-      - name: Checkout PR branch ${{ steps.comment-branch.outputs.head_ref }}
+      # Note: In GitHub's API, PRs are a type of issue, so github.event.issue.number is the PR number
+      # refs/pull/NUMBER/head is a special reference that works for both internal PRs and forks
+      - name: Checkout PR branch
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
-          repository: ${{ steps.comment-branch.outputs.head_repo }}
+          ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 0
 
       # Use GitHub Action secret to assume existing AWS IAM Role using OIDC connection
@@ -136,3 +140,6 @@ jobs:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
+          allowForks: true
+          targetUrl: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          context: ${{ github.workflow }}


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

This PR fixes the GitHub Actions workflow for Terraform testing to properly support pull requests from forks. The following changes were made:

1. Changed the checkout strategy to use GitHub's special PR reference syntax (`refs/pull/${{ github.event.issue.number }}/head`), which works for both internal PRs and forks.

2. Added `allowForks: true` to the commit status update steps to explicitly permit setting commit statuses on PRs from forks.

3. Added `targetUrl` and `context` parameters to the status update steps to provide better context for the status checks.

4. Added clarifying comments to explain GitHub's API design where PRs are treated as a type of issue.

### User experience

#### Before:

- PRs from branches in the main repository worked correctly
- PRs from forks failed with errors like:
  - "A branch or tag with the name 'fix/p4' could not be found" (checkout failure)
  - Status updates would fail silently for fork PRs

The workflow would fail when triggered on PRs from forks, preventing contributors from running the Terraform tests on their contributions.

#### After:

- PRs from branches in the main repository continue to work correctly
- PRs from forks now work correctly as well
- Status updates appear properly on PRs from forks
- Comments are posted on the PR regardless of whether it comes from a fork or not

Contributors can now trigger the Terraform tests on their PRs using the `/run-perforce-module-tf-tests` comment command, regardless of whether they're working in a branch on the main repository or in a fork. This improves the open-source contribution experience and ensures that all PRs can be properly tested before merging.
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
no
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.