### PR TITLE
feat(p4): allow users to specify a private ip

### DIFF
--- a/modules/perforce/main.tf
+++ b/modules/perforce/main.tf
@@ -51,6 +51,7 @@ module "p4_server" {
   # Networking & Security
   vpc_id                         = var.vpc_id
   instance_subnet_id             = var.p4_server_config.instance_subnet_id
+  instance_private_ip            = var.p4_server_config.instance_private_ip
   create_default_sg              = var.p4_server_config.create_default_sg
   existing_security_groups       = var.p4_server_config.existing_security_groups
   internal                       = var.p4_server_config.internal

--- a/modules/perforce/modules/p4-server/README.md
+++ b/modules/perforce/modules/p4-server/README.md
@@ -53,7 +53,7 @@ If you do not provide these the module will create a random Super User and creat
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.89.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.97.0 |
 | <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 1.34.0 |
 | <a name="provider_netapp-ontap"></a> [netapp-ontap](#provider\_netapp-ontap) | 2.1.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.7.1 |
@@ -128,6 +128,7 @@ No modules.
 | <a name="input_fsxn_svm_name"></a> [fsxn\_svm\_name](#input\_fsxn\_svm\_name) | FSxN storage virtual machine name | `string` | `null` | no |
 | <a name="input_fully_qualified_domain_name"></a> [fully\_qualified\_domain\_name](#input\_fully\_qualified\_domain\_name) | The fully qualified domain name where P4 Server will be available. This is used to generate self-signed certificates on the P4 Server. | `string` | `null` | no |
 | <a name="input_instance_architecture"></a> [instance\_architecture](#input\_instance\_architecture) | The architecture of the P4 Server instance. Allowed values are 'arm64' or 'x86\_64'. | `string` | `"x86_64"` | no |
+| <a name="input_instance_private_ip"></a> [instance\_private\_ip](#input\_instance\_private\_ip) | The private IP address to assign to the P4 Server. | `string` | `null` | no |
 | <a name="input_instance_subnet_id"></a> [instance\_subnet\_id](#input\_instance\_subnet\_id) | The subnet where the P4 Server instance will be deployed. | `string` | n/a | yes |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The instance type for Perforce P4 Server. Defaults to c6g.large. | `string` | `"c6i.large"` | no |
 | <a name="input_internal"></a> [internal](#input\_internal) | Set this flag to true if you do not want the P4 Server instance to have a public IP. | `bool` | `false` | no |
@@ -140,9 +141,9 @@ No modules.
 | <a name="input_protocol"></a> [protocol](#input\_protocol) | Specify the protocol (NFS or ISCSI) | `string` | `null` | no |
 | <a name="input_selinux"></a> [selinux](#input\_selinux) | Whether to apply SELinux label updates for P4 Server. Don't enable this if SELinux is disabled on your target operating system. | `bool` | `false` | no |
 | <a name="input_storage_type"></a> [storage\_type](#input\_storage\_type) | The type of backing store [EBS, FSxN] | `string` | n/a | yes |
-| <a name="input_super_user_password_secret_arn"></a> [super\_user\_password\_secret\_arn](#input\_super\_user\_password\_secret\_arn) | If you would like to manage your own super user credentials through AWS Secrets Manager provide the ARN for the super user's username here. Otherwise, the default of 'perforce' will be used. | `string` | `null` | no |
-| <a name="input_super_user_username_secret_arn"></a> [super\_user\_username\_secret\_arn](#input\_super\_user\_username\_secret\_arn) | If you would like to manage your own super user credentials through AWS Secrets Manager provide the ARN for the super user's password here. | `string` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br>  "IaC": "Terraform",<br>  "ModuleBy": "CGD-Toolkit",<br>  "ModuleName": "p4-server",<br>  "ModuleSource": "https://github.com/aws-games/cloud-game-development-toolkit/tree/main/modules/perforce/terraform-aws-perforce",<br>  "RootModuleName": "terraform-aws-perforce"<br>}</pre> | no |
+| <a name="input_super_user_password_secret_arn"></a> [super\_user\_password\_secret\_arn](#input\_super\_user\_password\_secret\_arn) | If you would like to manage your own super user credentials through AWS Secrets Manager provide the ARN for the super user's password here. | `string` | `null` | no |
+| <a name="input_super_user_username_secret_arn"></a> [super\_user\_username\_secret\_arn](#input\_super\_user\_username\_secret\_arn) | If you would like to manage your own super user credentials through AWS Secrets Manager provide the ARN for the super user's username here. Otherwise, the default of 'perforce' will be used. | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br/>  "IaC": "Terraform",<br/>  "ModuleBy": "CGD-Toolkit",<br/>  "ModuleName": "p4-server",<br/>  "ModuleSource": "https://github.com/aws-games/cloud-game-development-toolkit/tree/main/modules/perforce/terraform-aws-perforce",<br/>  "RootModuleName": "terraform-aws-perforce"<br/>}</pre> | no |
 | <a name="input_unicode"></a> [unicode](#input\_unicode) | Whether to enable Unicode configuration for P4 Server the -xi flag for p4d. Set to true to enable Unicode support. | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC where P4 Server should be deployed | `string` | n/a | yes |
 
@@ -156,6 +157,6 @@ No modules.
 | <a name="output_lambda_link_name"></a> [lambda\_link\_name](#output\_lambda\_link\_name) | Lambda function name for the FSxN Link |
 | <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | Private IP for the P4 Server instance |
 | <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | The default security group of your P4 Server instance. |
-| <a name="output_super_user_password_secret_arn"></a> [super\_user\_password\_secret\_arn](#output\_super\_user\_password\_secret\_arn) | The ARN of the AWS Secrets Manager secret holding your P4 Server super user's username. |
-| <a name="output_super_user_username_secret_arn"></a> [super\_user\_username\_secret\_arn](#output\_super\_user\_username\_secret\_arn) | The ARN of the AWS Secrets Manager secret holding your P4 Server super user's password. |
+| <a name="output_super_user_password_secret_arn"></a> [super\_user\_password\_secret\_arn](#output\_super\_user\_password\_secret\_arn) | The ARN of the AWS Secrets Manager secret holding your P4 Server super user's password. |
+| <a name="output_super_user_username_secret_arn"></a> [super\_user\_username\_secret\_arn](#output\_super\_user\_username\_secret\_arn) | The ARN of the AWS Secrets Manager secret holding your P4 Server super user's username. |
 <!-- END_TF_DOCS -->

--- a/modules/perforce/modules/p4-server/main.tf
+++ b/modules/perforce/modules/p4-server/main.tf
@@ -2,7 +2,7 @@
 # Perforce P4 Server Super User
 ##########################################
 resource "awscc_secretsmanager_secret" "super_user_password" {
-  count         = var.super_user_password_secret_arn == null ? 1 : 0
+  count       = var.super_user_password_secret_arn == null ? 1 : 0
   name        = "${local.name_prefix}-SuperUserPassword"
   description = "The password for the created P4 Server super user."
   generate_secret_string = {
@@ -13,7 +13,7 @@ resource "awscc_secretsmanager_secret" "super_user_password" {
 }
 
 resource "awscc_secretsmanager_secret" "super_user_username" {
-  count       = var.super_user_username_secret_arn == null ? 1 : 0
+  count         = var.super_user_username_secret_arn == null ? 1 : 0
   name          = "${local.name_prefix}-SuperUserUsername"
   description   = "The username for the created P4 Server super user."
   secret_string = "perforce"
@@ -79,6 +79,7 @@ resource "aws_instance" "server_instance" {
 
   availability_zone = local.p4_server_az
   subnet_id         = var.instance_subnet_id
+  private_ip        = var.instance_private_ip
 
   iam_instance_profile = aws_iam_instance_profile.instance_profile.id
 

--- a/modules/perforce/modules/p4-server/variables.tf
+++ b/modules/perforce/modules/p4-server/variables.tf
@@ -215,6 +215,12 @@ variable "instance_subnet_id" {
   description = "The subnet where the P4 Server instance will be deployed."
 }
 
+variable "instance_private_ip" {
+  type        = string
+  description = "The private IP address to assign to the P4 Server."
+  default     = null
+}
+
 variable "create_default_sg" {
   type        = bool
   description = "Whether to create a default security group for the P4 Server instance."

--- a/modules/perforce/variables.tf
+++ b/modules/perforce/variables.tf
@@ -209,6 +209,7 @@ variable "p4_server_config" {
 
     # Networking & Security
     instance_subnet_id       = optional(string, null)
+    instance_private_ip      = optional(string, null)
     create_default_sg        = optional(bool, true)
     existing_security_groups = optional(list(string), [])
     internal                 = optional(bool, false)
@@ -276,6 +277,8 @@ variable "p4_server_config" {
 
     # - Networking & Security -
     instance_subnet_id: "The subnet where the P4 Server instance will be deployed."
+
+    instance_private_ip: "The private IP address to assign to the P4 Server."
 
     create_default_sg : "Whether to create a default security group for the P4 Server instance."
 


### PR DESCRIPTION
## Summary

Perforce server licences are tied to the server's private IP address, so it can be desirable to let folks specify one.

### Changes

> Adds an input option to allow users to specify their Perforce server private IP.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No!
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.