### PR TITLE
chore: remove kevon from description :(

### DIFF
--- a/modules/perforce/examples/create-resources-complete/security.tf
+++ b/modules/perforce/examples/create-resources-complete/security.tf
@@ -14,7 +14,7 @@ data "http" "my_ip" {
 
 resource "aws_vpc_security_group_ingress_rule" "allow_https" {
   security_group_id = aws_security_group.allow_my_ip.id
-  description       = "Allow HTTPS traffic from Kevon."
+  description       = "Allow HTTPS traffic from my public IP."
   from_port         = 443
   to_port           = 443
   ip_protocol       = "tcp"
@@ -22,7 +22,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow_https" {
 }
 resource "aws_vpc_security_group_ingress_rule" "allow_http" {
   security_group_id = aws_security_group.allow_my_ip.id
-  description       = "Allow HTTP traffic from Kevon."
+  description       = "Allow HTTP traffic from my public IP."
   from_port         = 80
   to_port           = 80
   ip_protocol       = "tcp"
@@ -31,7 +31,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow_http" {
 
 resource "aws_vpc_security_group_ingress_rule" "allow_icmp" {
   security_group_id = aws_security_group.allow_my_ip.id
-  description       = "Allow ICMP traffic from Kevon."
+  description       = "Allow ICMP traffic from my public IP."
   from_port         = -1
   to_port           = -1
   ip_protocol       = "icmp"
@@ -39,7 +39,7 @@ resource "aws_vpc_security_group_ingress_rule" "allow_icmp" {
 }
 resource "aws_vpc_security_group_ingress_rule" "allow_perforce" {
   security_group_id = aws_security_group.allow_my_ip.id
-  description       = "Allow Perforce traffic from Kevon."
+  description       = "Allow Perforce traffic from my public IP."
   from_port         = 1666
   to_port           = 1666
   ip_protocol       = "tcp"


### PR DESCRIPTION
**Issue number:**
N/A

## Summary

### Changes

Updated security group rule descriptions in the Perforce example configuration to use generic language instead of personal references. Changed four security group ingress rule descriptions from referencing "Kevon" to "my public IP" for better generalization and professional documentation standards.

### User experience

**Before:**
- Security group rule descriptions contained personal references like "Allow HTTPS traffic from Kevon"
- Documentation appeared personalized to a specific developer
- Users might be confused by the personal reference in example code

**After:**
- Security group rule descriptions use generic language like "Allow HTTPS traffic from my public IP"
- Documentation is more professional and universally applicable
- Users can easily understand that the rules apply to their own public IP address
- Example code is more suitable for public consumption and reuse

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
no
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.