### PR TITLE
fix: fixes button/link to getting started page in homepage

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -40,7 +40,7 @@ Below are key tenets driving project's focus:
 
 ## Getting Started
 
-[Getting Started](https://aws-games.github.io/cloud-game-development-toolkit/latest/getting-started.html){ .md-button  }
+[Getting Started](../docs/getting-started.md){ .md-button  }
 
 ## License
 


### PR DESCRIPTION
**Issue number:** N/A

## Summary

Fixes button linking to getting started page at the bottom of index.md (homepage).

### Changes

Changed link attached to getting started button at the bottom of the index.md (homepage) of docs.

### User experience

Better experience navigating docs.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
no
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.