### PR TITLE
feat(p4-auth): allow specifying p4d_port with sensible default

### DIFF
--- a/modules/perforce/locals.tf
+++ b/modules/perforce/locals.tf
@@ -2,4 +2,9 @@ locals {
   # shared ECS cluster configuration
   create_shared_ecs_cluster = (var.existing_ecs_cluster_name == null &&
   (var.p4_auth_config != null || var.p4_code_review_config != null))
+
+  # This serves as a sensible default for p4d_port config options
+  p4_port = var.p4_server_config != null ? (
+    "%{if !var.p4_server_config.plaintext}ssl:%{endif}${var.p4_server_config.fully_qualified_domain_name}:1666"
+  ) : null
 }

--- a/modules/perforce/main.tf
+++ b/modules/perforce/main.tf
@@ -88,7 +88,7 @@ module "p4_auth" {
   container_port   = var.p4_auth_config.container_port
   container_cpu    = var.p4_auth_config.container_cpu
   container_memory = var.p4_auth_config.container_memory
-  p4d_port         = var.p4_auth_config.p4d_port
+  p4d_port         = var.p4_auth_config.p4d_port != null ? var.p4_auth_config.p4d_port : local.p4_port
 
   # Storage & Logging
   enable_alb_access_logs           = false
@@ -128,15 +128,11 @@ module "p4_code_review" {
     var.existing_ecs_cluster_name :
     aws_ecs_cluster.perforce_web_services_cluster[0].name
   )
-  container_name   = var.p4_code_review_config.container_name
-  container_port   = var.p4_code_review_config.container_port
-  container_cpu    = var.p4_code_review_config.container_cpu
-  container_memory = var.p4_code_review_config.container_memory
-  p4d_port = (
-    var.p4_code_review_config.p4d_port != null ?
-    var.p4_code_review_config.p4d_port :
-    "ssl:${var.create_route53_private_hosted_zone ? aws_route53_zone.perforce_private_hosted_zone[0].name : module.p4_server.private_ip}:1666"
-  )
+  container_name            = var.p4_code_review_config.container_name
+  container_port            = var.p4_code_review_config.container_port
+  container_cpu             = var.p4_code_review_config.container_cpu
+  container_memory          = var.p4_code_review_config.container_memory
+  p4d_port                  = var.p4_code_review_config.p4d_port != null ? var.p4_code_review_config.p4d_port : local.p4_port
   existing_redis_connection = var.p4_code_review_config.existing_redis_connection
 
   # Storage & Logging

--- a/modules/perforce/main.tf
+++ b/modules/perforce/main.tf
@@ -88,6 +88,7 @@ module "p4_auth" {
   container_port   = var.p4_auth_config.container_port
   container_cpu    = var.p4_auth_config.container_cpu
   container_memory = var.p4_auth_config.container_memory
+  p4d_port         = var.p4_auth_config.p4d_port
 
   # Storage & Logging
   enable_alb_access_logs           = false

--- a/modules/perforce/variables.tf
+++ b/modules/perforce/variables.tf
@@ -240,7 +240,7 @@ variable "p4_server_config" {
 
     auth_service_url: "The URL for the P4Auth Service."
 
-    fully_qualified_domain_name = "The FQDN for the P4Auth Service. This is used for the P4 Server's Perforce configuration."
+    fully_qualified_domain_name = "The FQDN for the P4 Server. This is used for the P4 Server's Perforce configuration."
 
 
     # - Compute -
@@ -339,6 +339,7 @@ variable "p4_auth_config" {
     container_port   = optional(number, 3000)
     container_cpu    = optional(number, 1024)
     container_memory = optional(number, 4096)
+    p4d_port         = optional(string, null)
 
     # - Storage & Logging -
     cloudwatch_log_retention_in_days = optional(number, 365)
@@ -383,6 +384,8 @@ variable "p4_auth_config" {
     container_cpu : "The number of CPU units to reserve for the P4Auth service container. Default is '1024'."
 
     container_memory : "The number of CPU units to reserve for the P4Auth service container. Default is '4096'."
+
+    pd4_port : "The full URL you will use to access the P4 Depot in clients such P4V and P4Admin. Note, this typically starts with 'ssl:' and ends with the default port of ':1666'."
 
 
     # Storage & Logging

--- a/modules/perforce/variables.tf
+++ b/modules/perforce/variables.tf
@@ -319,6 +319,11 @@ variable "p4_server_config" {
     error_message = "Not a valid storage type. Valid values are either 'EBS' or 'FSxN'."
   }
 
+  validation {
+    condition     = !var.create_route53_private_hosted_zone || var.route53_private_hosted_zone_name == var.p4_server_config.fully_qualified_domain_name
+    error_message = "Route53 zone name and Perforce Server FQDN must match."
+  }
+
 }
 
 ########################################


### PR DESCRIPTION
## Summary

Without this, logging into P4 CR with SSO didn't work as intended.

### Changes

* Allows the user to pass `p4d_port` into p4-auth if using the high-level `perforce` module.
* Adds default p4d_port detection when p4_server_config is passed
* Adds validation that p4_server fqdn matches the Route53 zone

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.