### PR TITLE
fix(p4-code-review): set SWARM_FORCE_EXT to fix token rollover

### DIFF
--- a/modules/perforce/modules/p4-code-review/main.tf
+++ b/modules/perforce/modules/p4-code-review/main.tf
@@ -117,6 +117,10 @@ resource "aws_ecs_task_definition" "task_definition" {
           {
             name  = "SWARM_REDIS_PORT" # cannot update naming until the Perforce container image is updated
             value = var.existing_redis_connection != null ? tostring(var.existing_redis_connection.port) : tostring(aws_elasticache_cluster.cluster[0].cache_nodes[0].port)
+          },
+          {
+            name  = "SWARM_FORCE_EXT"
+            value = "y"
           }
         ],
         readonlyRootFilesystem = false


### PR DESCRIPTION
## Summary

When a new deployment/task/container of P4 CR gets deployed, the trigger token is regenerated. Without this setting, the P4 extension config retains the old token, and the integration breaks.

### Changes

* Forces P4 CR to re-write it's extension config to P4D upon launch.

### User experience

This allows users to skip manually updating the trigger token upon redeployment.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.