### PR TITLE
feat(p4): support passing scim params to p4-code-review

### DIFF
--- a/modules/perforce/main.tf
+++ b/modules/perforce/main.tf
@@ -106,6 +106,11 @@ module "p4_auth" {
   admin_username_secret_arn = var.p4_auth_config.admin_username_secret_arn
   admin_password_secret_arn = var.p4_auth_config.admin_password_secret_arn
 
+  # SCIM
+  p4d_super_user_arn          = var.p4_auth_config.p4d_super_user_arn
+  p4d_super_user_password_arn = var.p4_auth_config.p4d_super_user_password_arn
+  scim_bearer_token_arn       = var.p4_auth_config.scim_bearer_token_arn
+
   depends_on = [aws_ecs_cluster.perforce_web_services_cluster[0]]
 }
 

--- a/modules/perforce/modules/p4-auth/variables.tf
+++ b/modules/perforce/modules/p4-auth/variables.tf
@@ -239,4 +239,9 @@ variable "scim_bearer_token_arn" {
   type        = string
   description = "If you would like to use SCIM to provision users and groups, you need to set this variable to the ARN of an AWS Secrets Manager secret containing the bearer token."
   default     = null
+
+  validation {
+    condition     = var.scim_bearer_token_arn == null || (var.p4d_super_user_arn != null && var.p4d_super_user_password_arn != null)
+    error_message = "scim_bearer_token_arn is only useful if p4d_super_user_arn and p4d_super_user_password_arn are also set, did you mean to set all three?"
+  }
 }

--- a/modules/perforce/variables.tf
+++ b/modules/perforce/variables.tf
@@ -360,6 +360,11 @@ variable "p4_auth_config" {
     custom_role               = optional(string, null)
     admin_username_secret_arn = optional(string, null)
     admin_password_secret_arn = optional(string, null)
+
+    # SCIM
+    p4d_super_user_arn          = optional(string, null)
+    p4d_super_user_password_arn = optional(string, null)
+    scim_bearer_token_arn       = optional(string, null)
   })
 
   default = null
@@ -410,6 +415,13 @@ variable "p4_auth_config" {
 
     admin_password_secret_arn : "Optionally provide the ARN of an AWS Secret for the P4Auth Administrator password."
 
+
+    # - SCIM -
+    p4d_super_user_arn : "If you would like to use SCIM to provision users and groups, you need to set this variable to the ARN of an AWS Secrets Manager secret containing the super user username for p4d."
+
+    p4d_super_user_password_arn : "If you would like to use SCIM to provision users and groups, you need to set this variable to the ARN of an AWS Secrets Manager secret containing the super user password for p4d."
+
+    scim_bearer_token_arn : "If you would like to use SCIM to provision users and groups, you need to set this variable to the ARN of an AWS Secrets Manager secret containing the bearer token."
 
 
   EOT


### PR DESCRIPTION
## Summary

This allows users to pass an SCIM config into P4 Auth.

### Changes

* Adds variables for passing super user login through to P4 auth
* Changes the way BEARER_TOKEN is passed in because P4 auth expects it to be base64 encoded

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.