### PR TITLE
feat(p4): add p4charset support to p4-code-review

### DIFF
--- a/modules/perforce/main.tf
+++ b/modules/perforce/main.tf
@@ -128,11 +128,16 @@ module "p4_code_review" {
     var.existing_ecs_cluster_name :
     aws_ecs_cluster.perforce_web_services_cluster[0].name
   )
-  container_name            = var.p4_code_review_config.container_name
-  container_port            = var.p4_code_review_config.container_port
-  container_cpu             = var.p4_code_review_config.container_cpu
-  container_memory          = var.p4_code_review_config.container_memory
-  p4d_port                  = var.p4_code_review_config.p4d_port != null ? var.p4_code_review_config.p4d_port : local.p4_port
+  container_name   = var.p4_code_review_config.container_name
+  container_port   = var.p4_code_review_config.container_port
+  container_cpu    = var.p4_code_review_config.container_cpu
+  container_memory = var.p4_code_review_config.container_memory
+  p4d_port         = var.p4_code_review_config.p4d_port != null ? var.p4_code_review_config.p4d_port : local.p4_port
+  p4charset = var.p4_code_review_config.p4charset != null ? var.p4_code_review_config.p4charset : (
+    var.p4_server_config != null ? (
+      var.p4_server_config.unicode ? "auto" : "none"
+    ) : "none"
+  )
   existing_redis_connection = var.p4_code_review_config.existing_redis_connection
 
   # Storage & Logging

--- a/modules/perforce/modules/p4-code-review/README.md
+++ b/modules/perforce/modules/p4-code-review/README.md
@@ -137,6 +137,7 @@ No modules.
 | <a name="input_name"></a> [name](#input\_name) | The name attached to P4 Code Review module resources. | `string` | `"p4-code-review"` | no |
 | <a name="input_p4_code_review_user_password_secret_arn"></a> [p4\_code\_review\_user\_password\_secret\_arn](#input\_p4\_code\_review\_user\_password\_secret\_arn) | Optionally provide the ARN of an AWS Secret for the p4d P4 Code Review password. | `string` | n/a | yes |
 | <a name="input_p4_code_review_user_username_secret_arn"></a> [p4\_code\_review\_user\_username\_secret\_arn](#input\_p4\_code\_review\_user\_username\_secret\_arn) | Optionally provide the ARN of an AWS Secret for the p4d P4 Code Review username. | `string` | n/a | yes |
+| <a name="input_p4charset"></a> [p4charset](#input\_p4charset) | The P4CHARSET environment variable to set in the P4 Code Review container. | `string` | `"none"` | no |
 | <a name="input_p4d_port"></a> [p4d\_port](#input\_p4d\_port) | The P4D\_PORT environment variable where P4 Code Review should look for P4 Code Review. Defaults to 'ssl:perforce:1666' | `string` | `"ssl:perforce:1666"` | no |
 | <a name="input_project_prefix"></a> [project\_prefix](#input\_project\_prefix) | The project prefix for this workload. This is appended to the beginning of most resource names. | `string` | `"cgd"` | no |
 | <a name="input_s3_enable_force_destroy"></a> [s3\_enable\_force\_destroy](#input\_s3\_enable\_force\_destroy) | Enables force destroy for the S3 bucket for P4 Code Review access log storage. Defaults to true. | `bool` | `true` | no |

--- a/modules/perforce/modules/p4-code-review/main.tf
+++ b/modules/perforce/modules/p4-code-review/main.tf
@@ -99,6 +99,10 @@ resource "aws_ecs_task_definition" "task_definition" {
         ]
         environment = [
           {
+            name  = "P4CHARSET"
+            value = var.p4charset
+          },
+          {
             name  = "P4D_PORT",
             value = var.p4d_port
           },

--- a/modules/perforce/modules/p4-code-review/variables.tf
+++ b/modules/perforce/modules/p4-code-review/variables.tf
@@ -74,6 +74,12 @@ variable "p4d_port" {
   default     = "ssl:perforce:1666"
 }
 
+variable "p4charset" {
+  type        = string
+  description = "The P4CHARSET environment variable to set in the P4 Code Review container."
+  default     = "none"
+}
+
 variable "existing_redis_connection" {
   type = object({
     host = string

--- a/modules/perforce/variables.tf
+++ b/modules/perforce/variables.tf
@@ -434,6 +434,7 @@ variable "p4_code_review_config" {
     container_cpu    = optional(number, 1024)
     container_memory = optional(number, 4096)
     p4d_port         = optional(string, null)
+    p4charset        = optional(string, null)
     existing_redis_connection = optional(object({
       host = string
       port = number
@@ -487,6 +488,8 @@ variable "p4_code_review_config" {
     container_memory : "The number of CPU units to reserve for the P4 Code Review service container. Default is '4096'."
 
     pd4_port : "The full URL you will use to access the P4 Depot in clients such P4V and P4Admin. Note, this typically starts with 'ssl:' and ends with the default port of ':1666'."
+
+    p4charset : "The P4CHARSET environment variable to set in the P4 Code Review container."
 
     existing_redis_connection : "The existing Redis connection for the P4 Code Review service."
 


### PR DESCRIPTION
## Summary

This allows setting `P4CHARSET` on p4-code-review, which is required for Unicode servers.

### Changes

* p4-code-review: Allow passing P4CHARSET to p4-code-review
* p4: Default P4CHARSET to `auto` when using a Unicode server

### User experience

Users will now be able to run P4 Code Review against Unicode P4 servers.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.