### PR TITLE
Add VPC creation capability to VDI terraform module

### DIFF
--- a/modules/vdi/examples/simple/README.md
+++ b/modules/vdi/examples/simple/README.md
@@ -1,10 +1,15 @@
-# Simple VDI Example
+# VDI Example with VPC Creation
 
-This example demonstrates how to use the VDI module to create a Virtual Desktop Infrastructure instance on AWS.
+This example demonstrates how to use the VDI module to create a Virtual Desktop Infrastructure instance on AWS with a new VPC containing public and private subnets.
 
 ## What This Example Creates
 
-- A Windows Server 2025-based VDI instance using a custom AMI
+- A complete VPC infrastructure:
+  - Public and private subnets across multiple availability zones
+  - Internet Gateway for public subnet connectivity
+  - NAT Gateway for private subnet outbound access
+  - Appropriate route tables for network traffic
+- A Windows Server 2025-based VDI instance in a private subnet
 - Security group with RDP and NICE DCV access
 - IAM role and instance profile for AWS Systems Manager integration
 - EBS volumes with encryption enabled
@@ -14,11 +19,11 @@ This example demonstrates how to use the VDI module to create a Virtual Desktop 
 
 1. **Custom AMI**: Ensure you have built the Windows Server 2025 AMI using the Packer template located at `assets/packer/virtual-workstations/windows/windows-server-2025.pkr.hcl`
 
-2. **VPC and Subnet**: Update the `vpc_id` and `subnet_id` values in `main.tf` with your actual VPC and subnet IDs
+2. **Network Planning**: Review the CIDR blocks and availability zones in the example to ensure they're suitable for your environment
 
-3. **Key Pair**: (Optional) Create an EC2 key pair if you want to use an existing key instead of letting the module auto-generate one
+3. **AWS Credentials**: Ensure your AWS credentials are configured (via AWS CLI, environment variables, or IAM roles)
 
-4. **AWS Credentials**: Ensure your AWS credentials are configured (via AWS CLI, environment variables, or IAM roles)
+4. **AWS Limits**: Verify you have sufficient quotas for VPC resources (NAT Gateways, Elastic IPs, etc.)
 
 ## Usage
 
@@ -27,11 +32,13 @@ This example demonstrates how to use the VDI module to create a Virtual Desktop 
    cd modules/vdi/examples/simple
    ```
 
-2. Update the configuration in `main.tf`:
-   - Replace `vpc-12345678` with your actual VPC ID
-   - Replace `subnet-12345678` with your actual subnet ID
-   - (Optional) Uncomment the `key_pair_name` line and replace with your actual key pair name if you're not using auto-generated keys
-   - Adjust CIDR blocks for security group rules as needed
+2. Review and update the configuration in `main.tf` as needed:
+   - Adjust VPC CIDR block (`vpc_cidr`) if needed
+   - Modify public and private subnet CIDR blocks (`public_subnet_cidrs` and `private_subnet_cidrs`)
+   - Uncomment and set specific availability zones if required (`availability_zones`)
+   - Adjust NAT Gateway configuration based on requirements
+   - Set security group access rules (`allowed_cidr_blocks`)
+   - Configure instance type and storage settings as needed
 
 3. Initialize Terraform:
    ```bash
@@ -55,6 +62,13 @@ This example demonstrates how to use the VDI module to create a Virtual Desktop 
 
 ## Configuration Options
 
+### VPC and Networking
+- **VPC CIDR**: Default is `10.0.0.0/16` - adjust based on your IP addressing plan
+- **Public Subnets**: Default is `["10.0.101.0/24", "10.0.102.0/24"]` - used for NAT Gateways
+- **Private Subnets**: Default is `["10.0.1.0/24", "10.0.2.0/24"]` - where VDI instances are deployed
+- **NAT Gateway**: Enable/disable NAT Gateway for private subnet internet access
+- **Single NAT Gateway**: Use one NAT Gateway for all private subnets to reduce costs
+
 ### Instance Type
 The example uses `g4dn.2xlarge` which provides GPU capabilities suitable for graphics-intensive workloads. You can change this to other instance types based on your needs:
 - `t3.large` - General purpose, cost-effective
@@ -68,35 +82,64 @@ The example includes:
 - Additional file storage volume: 1000 GB GP3 volume
 
 ### Security
-- RDP access is restricted to private networks (10.0.0.0/8)
-- The instance is deployed without a public IP by default
+- RDP and NICE DCV access is restricted to private networks (10.0.0.0/8)
+- The instance is deployed in a private subnet with NAT Gateway for outbound internet access
+- No public IP is assigned to the instance by default
 - EBS encryption is enabled for all volumes
 
 ## Accessing the VDI Instance
 
-Once deployed, you can access the VDI instance via:
+Since the VDI instance is deployed in a private subnet, you'll need one of the following methods to access it:
 
-1. **RDP**: Use Remote Desktop Protocol to connect to the instance's private IP
+1. **Bastion Host**: Deploy a bastion host in one of the public subnets and connect through it
 2. **AWS Systems Manager Session Manager**: Connect through the AWS console without needing direct network access
-3. **VPN/Bastion Host**: If deployed in a private subnet, use a VPN or bastion host for access
+3. **VPN Connection**: Set up a VPN to connect to resources in the private subnet
+4. **Direct Connect**: For enterprise environments, consider using AWS Direct Connect
 
 ## Outputs
 
 After deployment, the following information will be available:
 
+### VPC and Networking
+- `vpc_id`: The ID of the created VPC
+- `public_subnet_ids`: List of public subnet IDs
+- `private_subnet_ids`: List of private subnet IDs
+- `internet_gateway_id`: ID of the Internet Gateway
+- `nat_gateway_ids`: List of NAT Gateway IDs
+
+### VDI Instance
 - `vdi_instance_id`: The EC2 instance ID
 - `vdi_private_ip`: The private IP address of the instance
 - `vdi_public_ip`: The public IP address (if assigned)
 - `ami_used`: Information about the AMI used
 - `security_group_id`: The security group ID
+- `credentials_secret_id`: The ID of the AWS Secrets Manager secret containing credentials
 
 ## Cost Considerations
 
-- `g4dn.2xlarge` instances can be expensive. Consider using smaller instance types for development/testing
-- GP3 volumes with high IOPS/throughput settings increase costs
-- Consider using Spot instances for non-production workloads to reduce costs
+- **NAT Gateway**: NAT Gateways incur hourly charges and data processing fees
+- **VDI Instances**: `g4dn.2xlarge` instances can be expensive. Consider using smaller instance types for development/testing
+- **Storage**: GP3 volumes with high IOPS/throughput settings increase costs
+- **Cost Saving Options**:
+  - Set `single_nat_gateway = true` to use one NAT Gateway for all private subnets
+  - Consider using Spot instances for non-production VDI workloads
+  - Shut down instances when not in use
 
 ## Troubleshooting
+
+### VPC Creation Issues
+If VPC creation fails:
+1. Check that you have sufficient permissions to create VPC resources
+2. Verify the CIDR blocks don't overlap with existing VPCs
+3. Ensure the specified availability zones are valid for your region
+4. Check AWS service quotas for VPC resources
+
+### NAT Gateway Issues
+If instances in private subnets cannot access the internet:
+1. Check the NAT Gateway status in the AWS Console
+2. Verify the route tables for private subnets include routes to the NAT Gateway
+3. Check that the Internet Gateway is properly attached to the VPC
+4. Verify the Elastic IP for the NAT Gateway is properly allocated
 
 ### AMI Not Found
 If you get an error about the AMI not being found:
@@ -107,8 +150,8 @@ If you get an error about the AMI not being found:
 ### Network Connectivity Issues
 If you can't connect to the instance:
 1. Check security group rules
-2. Verify the instance is in the correct subnet
-3. Ensure your network can reach the instance's IP address
+2. Verify the instance is in the private subnet
+3. Ensure you have a proper method to access the private subnet (bastion host, VPN, SSM)
 4. Check that the Windows firewall allows RDP connections
 
 ### Instance Launch Failures

--- a/modules/vdi/outputs.tf
+++ b/modules/vdi/outputs.tf
@@ -1,3 +1,30 @@
+# VPC Outputs
+output "vpc_id" {
+  description = "The ID of the VPC (created or provided)"
+  value       = local.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "List of public subnet IDs (only when create_vpc = true)"
+  value       = var.create_vpc ? aws_subnet.vdi_public_subnet[*].id : []
+}
+
+output "private_subnet_ids" {
+  description = "List of private subnet IDs (only when create_vpc = true)"
+  value       = var.create_vpc ? aws_subnet.vdi_private_subnet[*].id : []
+}
+
+output "internet_gateway_id" {
+  description = "ID of the Internet Gateway (only when create_vpc = true)"
+  value       = var.create_vpc ? aws_internet_gateway.vdi_igw[0].id : null
+}
+
+output "nat_gateway_ids" {
+  description = "List of NAT Gateway IDs (only when create_vpc = true and enable_nat_gateway = true)"
+  value       = var.create_vpc && var.enable_nat_gateway ? aws_nat_gateway.vdi_nat_gateway[*].id : []
+}
+
+# Instance Outputs
 output "vdi_instance_id" {
   description = "The ID of the VDI EC2 instance"
   value       = var.create_instance ? aws_instance.vdi_instance[0].id : null

--- a/modules/vdi/variables.tf
+++ b/modules/vdi/variables.tf
@@ -39,22 +39,64 @@ variable "tags" {
 # NETWORKING CONFIGURATION
 ########################################
 
+variable "create_vpc" {
+  type        = bool
+  description = "Whether to create a new VPC for the VDI instance."
+  default     = false
+}
+
 variable "vpc_id" {
   type        = string
-  description = "The ID of the existing VPC to deploy the VDI instance into."
-  # TODO: Replace with actual VPC ID reference when VPC module is identified
-  default = "vpc-placeholder-replace-with-actual-vpc-id"
+  description = "The ID of the existing VPC to deploy the VDI instance into. Required if create_vpc is false."
+  default     = null
+}
+
+variable "vpc_cidr" {
+  type        = string
+  description = "The CIDR block for the VPC. Only used if create_vpc is true."
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "List of CIDR blocks for public subnets. Only used if create_vpc is true."
+  default     = ["10.0.101.0/24", "10.0.102.0/24"]
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "List of CIDR blocks for private subnets. Only used if create_vpc is true."
+  default     = ["10.0.1.0/24", "10.0.2.0/24"]
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "List of availability zones to use for the subnets. Only used if create_vpc is true."
+  default     = []
 }
 
 variable "subnet_id" {
   type        = string
-  description = "The subnet ID to deploy the VDI instance into. Private subnet is recommended for security."
+  description = "The subnet ID to deploy the VDI instance into. Private subnet is recommended for security. Required if create_vpc is false."
+  default     = null
 }
 
 variable "associate_public_ip_address" {
   type        = bool
   description = "Whether to associate a public IP address with the VDI instance."
   default     = false
+}
+
+variable "enable_nat_gateway" {
+  type        = bool
+  description = "Whether to enable NAT Gateway for the private subnets. Only used if create_vpc is true."
+  default     = true
+}
+
+variable "single_nat_gateway" {
+  type        = bool
+  description = "Whether to use a single NAT Gateway for all private subnets. Only used if create_vpc is true and enable_nat_gateway is true."
+  default     = true
 }
 
 ########################################


### PR DESCRIPTION
This commit adds the ability to create a new VPC with public and private subnets to the VDI module.

Key changes:
- Added variables for VPC CIDR, subnet CIDRs, and NAT Gateway configuration
- Implemented VPC, subnet, Internet Gateway and NAT Gateway resources
- Updated security group and instance configurations to use the new VPC
- Added outputs for VPC resources
- Updated documentation and examples to demonstrate the new functionality

The module maintains backward compatibility with existing VPC usage.

**Issue number:**

## Summary

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
