### PR TITLE
feat(horde): serverless elasticache

### DIFF
--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -54,6 +54,7 @@ No modules.
 | [aws_ecs_task_definition.unreal_horde_task_definition](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/ecs_task_definition) | resource |
 | [aws_elasticache_cluster.horde](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/elasticache_cluster) | resource |
 | [aws_elasticache_replication_group.horde](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/elasticache_replication_group) | resource |
+| [aws_elasticache_serverless_cache.horde](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/elasticache_serverless_cache) | resource |
 | [aws_elasticache_subnet_group.horde](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/elasticache_subnet_group) | resource |
 | [aws_iam_instance_profile.unreal_horde_agent_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_policy.horde_agents_s3_policy](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_policy) | resource |
@@ -163,6 +164,8 @@ No modules.
 | <a name="input_elasticache_port"></a> [elasticache\_port](#input\_elasticache\_port) | The port for the ElastiCache cluster. | `number` | `6379` | no |
 | <a name="input_elasticache_redis_engine_version"></a> [elasticache\_redis\_engine\_version](#input\_elasticache\_redis\_engine\_version) | The version of the Redis engine to use. | `string` | `"7.0"` | no |
 | <a name="input_elasticache_redis_parameter_group_name"></a> [elasticache\_redis\_parameter\_group\_name](#input\_elasticache\_redis\_parameter\_group\_name) | The name of the Redis parameter group to use. | `string` | `"default.redis7"` | no |
+| <a name="input_elasticache_serverless"></a> [elasticache\_serverless](#input\_elasticache\_serverless) | Whether to use an elasticache serverless deployment | `bool` | `false` | no |
+| <a name="input_elasticache_serverless_usesage_limits"></a> [elasticache\_serverless\_usesage\_limits](#input\_elasticache\_serverless\_usesage\_limits) | Whether to use an elasticache serverless deployment | <pre>object({<br/>    data_storage = object({<br/>      minimum = number<br/>      maximum = number<br/>    })<br/>    ecpu_per_second = object({<br/>      minimum = number<br/>      maximum = number<br/>    })<br/>  })</pre> | `null` | no |
 | <a name="input_elasticache_snapshot_retention_limit"></a> [elasticache\_snapshot\_retention\_limit](#input\_elasticache\_snapshot\_retention\_limit) | The number of Elasticache snapshots to retain. | `number` | `5` | no |
 | <a name="input_elasticache_valkey_engine_version"></a> [elasticache\_valkey\_engine\_version](#input\_elasticache\_valkey\_engine\_version) | The version of the ElastiCache engine to use. | `string` | `"7.2"` | no |
 | <a name="input_elasticache_valkey_parameter_group_name"></a> [elasticache\_valkey\_parameter\_group\_name](#input\_elasticache\_valkey\_parameter\_group\_name) | The name of the Valkey parameter group to use. | `string` | `"default.valkey7"` | no |

--- a/modules/unreal/horde/elasticache.tf
+++ b/modules/unreal/horde/elasticache.tf
@@ -1,13 +1,38 @@
 # Subnet Group for Horde Elasticache
 resource "aws_elasticache_subnet_group" "horde" {
-  count      = var.custom_cache_connection_config == null ? 1 : 0
+  count      = var.custom_cache_connection_config == null && !var.elasticache_serverless ? 1 : 0
   name       = "${var.name}-elasticache-subnet-group"
   subnet_ids = var.unreal_horde_service_subnets
 }
 
+# Serverless Elasticache deployment
+resource "aws_elasticache_serverless_cache" "horde" {
+  count = var.elasticache_serverless ? 1 : 0
+
+  name                 = "${var.project_prefix}-${var.name}-elasticache"
+  description          = "Elasticache deployment for Unreal Horde"
+  engine               = var.elasticache_engine
+  major_engine_version = var.elasticache_engine == "redis" ? var.elasticache_redis_engine_version : var.elasticache_valkey_engine_version
+
+  security_group_ids = [aws_security_group.unreal_horde_elasticache_sg[0].id]
+  subnet_ids         = var.unreal_horde_service_subnets
+
+  cache_usage_limits {
+    data_storage {
+      unit    = "GB"
+      minimum = var.elasticache_serverless_usesage_limits.data_storage.minimum
+      maximum = var.elasticache_serverless_usesage_limits.data_storage.maximum
+    }
+    ecpu_per_second {
+      minimum = var.elasticache_serverless_usesage_limits.ecpu_per_second.minimum
+      maximum = var.elasticache_serverless_usesage_limits.ecpu_per_second.maximum
+    }
+  }
+}
+
 # Single Node Elasticache Cluster for Horde
 resource "aws_elasticache_cluster" "horde" {
-  count                = var.elasticache_engine == "redis" && var.custom_cache_connection_config == null ? 1 : 0
+  count                = !var.elasticache_serverless && var.elasticache_engine == "redis" && var.custom_cache_connection_config == null ? 1 : 0
   cluster_id           = "${var.name}-elasticache-redis-cluster"
   engine               = "redis"
   node_type            = var.elasticache_node_type
@@ -24,7 +49,7 @@ resource "aws_elasticache_cluster" "horde" {
 # Valkey with Cluster Mode Disabled
 resource "aws_elasticache_replication_group" "horde" {
   automatic_failover_enabled = true
-  count                      = var.elasticache_engine == "valkey" && var.custom_cache_connection_config == null ? 1 : 0
+  count                      = !var.elasticache_serverless && var.elasticache_engine == "valkey" && var.custom_cache_connection_config == null ? 1 : 0
   engine                     = "valkey"
   engine_version             = var.elasticache_valkey_engine_version
   replication_group_id       = "${var.name}-elasticache-valkey-rep-grp"

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -39,10 +39,9 @@ data "aws_iam_policy_document" "unreal_horde_elasticache_policy" {
     actions = [
       "elasticache:Connect"
     ]
-    resources = (var.elasticache_engine == "redis" ?
-      [aws_elasticache_cluster.horde[0].arn] :
-    [aws_elasticache_replication_group.horde[0].arn])
-
+    resources = (var.elasticache_serverless ? [aws_elasticache_serverless_cache.horde[0].arn] :
+      var.elasticache_engine == "redis" ? [aws_elasticache_cluster.horde[0].arn] : [aws_elasticache_replication_group.horde[0].arn]
+    )
   }
 }
 

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -13,11 +13,13 @@ locals {
     "environment" = var.environment
   })
 
-  elasticache_redis_connection_strings = var.elasticache_engine == "redis" ? [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"] : null
+  elasticache_serverless_connection_strings = var.elasticache_serverless ? concat([for endpoint in aws_elasticache_serverless_cache.horde[0].endpoint : "${endpoint.address}:${endpoint.port}"], ["ssl=true"]) : null
 
-  elasticache_valkey_connection_strings = var.elasticache_engine == "valkey" ? "${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${var.elasticache_port}" : null
+  elasticache_redis_connection_strings = !var.elasticache_serverless && var.elasticache_engine == "redis" ? [for node in aws_elasticache_cluster.horde[0].cache_nodes : "${node.address}:${node.port}"] : null
 
-  redis_connection_config = var.custom_cache_connection_config != null ? var.custom_cache_connection_config : (var.elasticache_engine == "redis" ? join(",", local.elasticache_redis_connection_strings) : local.elasticache_valkey_connection_strings)
+  elasticache_valkey_connection_strings = !var.elasticache_serverless && var.elasticache_engine == "valkey" ? ["${aws_elasticache_replication_group.horde[0].primary_endpoint_address}:${var.elasticache_port}"] : null
+
+  redis_connection_config = var.custom_cache_connection_config != null ? var.custom_cache_connection_config : join(",", var.elasticache_serverless ? local.elasticache_serverless_connection_strings : var.elasticache_engine == "redis" ? local.elasticache_redis_connection_strings : local.elasticache_valkey_connection_strings)
 
   database_connection_string = var.database_connection_string != null ? var.database_connection_string : "mongodb://${var.docdb_master_username}:${var.docdb_master_password}@${aws_docdb_cluster.horde[0].endpoint}:27017/?tls=true&tlsCAFile=/app/config/global-bundle.pem&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false"
 

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -366,15 +366,56 @@ variable "elasticache_engine" {
   }
 }
 
+variable "elasticache_serverless" {
+  description = "Whether to use an elasticache serverless deployment"
+  type        = bool
+  default     = false
+
+  validation {
+    condition     = var.elasticache_serverless == false || var.custom_cache_connection_config == null
+    error_message = "elasticache_serverless cannot be set if an external cache connection is configured."
+  }
+}
+
+variable "elasticache_serverless_usesage_limits" {
+  description = "Whether to use an elasticache serverless deployment"
+  type = object({
+    data_storage = object({
+      minimum = number
+      maximum = number
+    })
+    ecpu_per_second = object({
+      minimum = number
+      maximum = number
+    })
+  })
+  default = null
+
+  validation {
+    condition     = var.elasticache_serverless == false || var.elasticache_serverless_usesage_limits != null
+    error_message = "elasticache_serverless_usesage_limits must be set if elasticache_serverless is enabled."
+  }
+}
+
 variable "elasticache_redis_engine_version" {
   type        = string
   description = "The version of the Redis engine to use."
   default     = "7.0"
+
+  validation {
+    condition     = !(var.elasticache_serverless && var.elasticache_engine == "redis" && strcontains(var.elasticache_redis_engine_version, "."))
+    error_message = "When using elasticache_serverless, var.elasticache_redis_engine_version must be a MAJOR version only."
+  }
 }
 variable "elasticache_valkey_engine_version" {
   type        = string
   description = "The version of the ElastiCache engine to use."
   default     = "7.2"
+
+  validation {
+    condition     = !(var.elasticache_serverless && var.elasticache_engine == "valkey" && strcontains(var.elasticache_valkey_engine_version, "."))
+    error_message = "When using elasticache_serverless, var.elasticache_valkey_engine_version must be a MAJOR version only."
+  }
 }
 
 variable "elasticache_redis_parameter_group_name" {


### PR DESCRIPTION
## Summary

This adds support for using a serverless elasticache instance instead of a provisioned cluster.

### Changes

* Adds configurable `aws_elasticache_serverless_cache` that can be used instead of fixed clusters
* Adds necessary configuration
* Adds connection string generation **NOTE**: the `ssl=true` is _mandatory_ for serverless clusters.

### User experience

The users may now opt into using serverless elasticache clusters.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
Nope! All new functionality.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
