### PR TITLE
feat: Add GH action for VDI module with TF Test

### DIFF
--- a/.github/workflows/tf-test-on-comment-modules-vdi.yml
+++ b/.github/workflows/tf-test-on-comment-modules-vdi.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Checkout PR branch ${{ steps.comment-branch.outputs.head_ref }}
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.comment-branch.outputs.head_ref }}
+          ref: ${{ steps.comment-branch.outputs.head_sha }}
           repository: ${{ steps.comment-branch.outputs.head_repo }}
           fetch-depth: 0
 


### PR DESCRIPTION
**Issue number:**
N/A
## Summary

### Changes

A new GitHub Actions workflow file `tf-test-on-comment-modules-vdi.yml` was added to enable on-demand Terraform testing for the VDI module. The workflow is triggered by PR comments containing `/run-vdi-module-tf-tests` and runs comprehensive Terraform validation including formatting checks, initialization, and test execution with AWS credentials via OIDC.

### User experience

**Before**: Developers working on the VDI module had no automated way to run Terraform tests on-demand for their pull requests. Testing would need to be done manually or wait for standard CI/CD pipeline execution.

**After**: Developers can now trigger VDI module Terraform tests by simply commenting `/run-vdi-module-tf-tests` on any pull request. The workflow provides real-time feedback through PR comments, showing when tests are scheduled, in progress, and completed with success/failure status and links to the full GitHub Actions run. This currently will only work for PRs submitted from branches of this source repo. Forks are not supported yet, but will be added via #664.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
no
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
