### PR TITLE
fix(horde): migrate iam policies off of deprecated managed_policy_arns

### DIFF
--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -63,7 +63,10 @@ No modules.
 | [aws_iam_role.unreal_horde_agent_default_role](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_role) | resource |
 | [aws_iam_role.unreal_horde_default_role](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_role) | resource |
 | [aws_iam_role.unreal_horde_task_execution_role](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.unreal_horde_default_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.unreal_horde_elasticache_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.unreal_horde_secrets_manager_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.unreal_horde_task_execution_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_launch_template.unreal_horde_agent_template](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/launch_template) | resource |
 | [aws_lb.unreal_horde_external_alb](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/lb) | resource |
 | [aws_lb.unreal_horde_internal_alb](https://registry.terraform.io/providers/hashicorp/aws/6.6.0/docs/resources/lb) | resource |

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -69,10 +69,6 @@ resource "aws_iam_role" "unreal_horde_default_role" {
   name               = "${var.project_prefix}-unreal_horde-default-role"
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
 
-  managed_policy_arns = [
-    aws_iam_policy.unreal_horde_default_policy[0].arn
-  ]
-
   tags = local.tags
 }
 
@@ -82,6 +78,13 @@ resource "aws_iam_role_policy_attachment" "unreal_horde_elasticache_policy_attac
 
   role       = aws_iam_role.unreal_horde_default_role[0].name
   policy_arn = aws_iam_policy.unreal_horde_elasticache_policy[0].arn
+}
+
+resource "aws_iam_role_policy_attachment" "unreal_horde_default_policy_attachment" {
+  count = var.create_unreal_horde_default_policy ? 1 : 0
+
+  role       = aws_iam_role.unreal_horde_default_role[0].name
+  policy_arn = aws_iam_policy.unreal_horde_default_policy[0].arn
 }
 
 
@@ -115,7 +118,16 @@ resource "aws_iam_role" "unreal_horde_task_execution_role" {
   name = "${var.project_prefix}-unreal_horde-task-execution-role"
 
   assume_role_policy = data.aws_iam_policy_document.ecs_tasks_trust_relationship.json
-  managed_policy_arns = concat([
-    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
-  ], [for policy in aws_iam_policy.unreal_horde_secrets_manager_policy : policy.arn])
+}
+
+resource "aws_iam_role_policy_attachment" "unreal_horde_task_execution_policy_attachment" {
+  role       = aws_iam_role.unreal_horde_task_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "unreal_horde_secrets_manager_policy_attachment" {
+  for_each = toset(aws_iam_policy.unreal_horde_secrets_manager_policy[*].arn)
+
+  role       = aws_iam_role.unreal_horde_task_execution_role.name
+  policy_arn = each.key
 }


### PR DESCRIPTION
## Summary

Terraform has been issuing a deprecation warning for the `aws_iam_role.managed_policy_arns` field. This ports from that field to separate policy attachment resources. This was also causing issues with the elasticache policy, as mixing policy attachment resources with `managed_policy_arns` was causing the attachment to get detached and re-attached per-apply.

### Changes

Migrates iam policies off of deprecated managed_policy_arns

### User experience

User will stop receiving deprecation warnings.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
