### PR TITLE
fix(unreal/horde): use bash image from public ECR instead of Docker Hub

### DIFF
--- a/modules/unreal/horde/ecs.tf
+++ b/modules/unreal/horde/ecs.tf
@@ -114,7 +114,7 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
     },
     {
       name                     = "unreal-horde-docdb-cert",
-      image                    = "bash",
+      image                    = "public.ecr.aws/docker/library/bash:5.3",
       essential                = false
       command                  = ["wget", "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem", "-P", "/app/config/"]
       readonly_root_filesystem = false


### PR DESCRIPTION
Prevents potential rate limiting issues with Docker Hub pulls

**Issue number:** N/A

## Summary

### Changes

> Please provide a summary of what's being changed

This changes the docdb-cert container image from bash on Docker Hub to bash on Public ECR Gallery, which prevents issues with rate limiting on pulls.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
