### PR TITLE
fix(horde): upgrade horde agent to .NET 8.0 runtime for UE 5.6 compatibility

### DIFF
--- a/modules/unreal/horde/config/agent/horde-agent.ansible.yml
+++ b/modules/unreal/horde/config/agent/horde-agent.ansible.yml
@@ -17,7 +17,7 @@
       when: ansible_distribution == "Ubuntu"
     - name: Install DotNet
       ansible.builtin.package:
-        name: dotnet-runtime-6.0
+        name: dotnet-runtime-8.0 # Unreal Engine 5.6 needs DotNet runtime version 8; previous versions require version 6 instead
         state: present
     - name: Check if i386 enabled
       ansible.builtin.shell:


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

> Please provide a summary of what's being changed

This upgrades horde agent to .NET 8.0 runtime for UE 5.6 compatibility. Unclear at this moment whether this also works for UE <= 5.5.

### User experience

> Please share what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
Possibly - I did not test this on Unreal Engine 5.5, only 5.6.x, where I've confirmed it works.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
