### PR TITLE
feat(horde): parameterize dotnet version installed on agents

### DIFF
--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -133,6 +133,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_admin_claim_type"></a> [admin\_claim\_type](#input\_admin\_claim\_type) | The claim type for administrators. | `string` | `null` | no |
 | <a name="input_admin_claim_value"></a> [admin\_claim\_value](#input\_admin\_claim\_value) | The claim value for administrators. | `string` | `null` | no |
+| <a name="input_agent_dotnet_runtime_version"></a> [agent\_dotnet\_runtime\_version](#input\_agent\_dotnet\_runtime\_version) | The dotnet-runtime-{} package to install (see your engine version's release notes for supported version) | `string` | `"6.0"` | no |
 | <a name="input_agents"></a> [agents](#input\_agents) | Configures autoscaling groups to be used as build agents by Unreal Engine Horde. | <pre>map(object({<br/>    ami           = string<br/>    instance_type = string<br/>    block_device_mappings = list(<br/>      object({<br/>        device_name = string<br/>        ebs = object({<br/>          volume_size = number<br/>        })<br/>      })<br/>    )<br/>    min_size = optional(number, 0)<br/>    max_size = optional(number, 1)<br/>  }))</pre> | `{}` | no |
 | <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | The authentication method for the Horde server. | `string` | `null` | no |
 | <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | The TLS certificate ARN for the Unreal Horde load balancer. | `string` | n/a | yes |

--- a/modules/unreal/horde/asg.tf
+++ b/modules/unreal/horde/asg.tf
@@ -192,7 +192,7 @@ resource "aws_ssm_association" "configure_unreal_horde_agent" {
   parameters = {
     SourceInfo     = "{\"path\":\"https://${aws_s3_bucket.ansible_playbooks[0].bucket_domain_name}/agent/\"}"
     PlaybookFile   = "horde-agent.ansible.yml"
-    ExtraVariables = "horde_server_url=${var.fully_qualified_domain_name}"
+    ExtraVariables = "horde_server_url=${var.fully_qualified_domain_name} dotnet_runtime_version=${var.agent_dotnet_runtime_version}"
   }
 
   output_location {

--- a/modules/unreal/horde/config/agent/horde-agent.ansible.yml
+++ b/modules/unreal/horde/config/agent/horde-agent.ansible.yml
@@ -17,7 +17,7 @@
       when: ansible_distribution == "Ubuntu"
     - name: Install DotNet
       ansible.builtin.package:
-        name: dotnet-runtime-6.0
+        name: dotnet-runtime-{{ dotnet_runtime_version }}
         state: present
     - name: Check if i386 enabled
       ansible.builtin.shell:

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -481,6 +481,12 @@ variable "agents" {
   default     = {}
 }
 
+variable "agent_dotnet_runtime_version" {
+  type        = string
+  description = "The dotnet-runtime-{} package to install (see your engine version's release notes for supported version)"
+  default     = "6.0"
+}
+
 variable "fully_qualified_domain_name" {
   type        = string
   description = "The fully qualified domain name where your Unreal Engine Horde server will be available. This agents will use this to enroll."


### PR DESCRIPTION
## Summary

Different versions of Unreal use different versions of the dotnet runtime (<5.6 uses 6.0, >=5.6 uses 8.0). This allows users to specify which version of the dotnet runtime to install based on their Horde version and/or any modifications they've made.

### Changes

Pipes through a `agent_dotnet_runtime_version` input to the ansible playbook.

### User experience

Users may install whichever version of dotnet they would like.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
