### PR TITLE
fsxn report usage

### DIFF
--- a/modules/perforce/main.tf
+++ b/modules/perforce/main.tf
@@ -47,6 +47,8 @@ module "p4_server" {
   fsxn_password                     = var.p4_server_config.fsxn_password
   fsxn_region                       = var.p4_server_config.fsxn_region
   fsxn_management_ip                = var.p4_server_config.fsxn_management_ip
+  fsxn_report_usage                 = var.p4_server_config.fsxn_report_usage
+
 
   # Networking & Security
   vpc_id                         = var.vpc_id

--- a/modules/perforce/modules/p4-server/data.tf
+++ b/modules/perforce/modules/p4-server/data.tf
@@ -28,3 +28,5 @@ data "aws_ami" "existing_server_ami" {
     values = [var.instance_architecture]
   }
 }
+
+data "aws_region" "current" {}

--- a/modules/perforce/modules/p4-server/variables.tf
+++ b/modules/perforce/modules/p4-server/variables.tf
@@ -161,6 +161,14 @@ variable "fsxn_region" {
   }
 }
 
+
+variable "fsxn_report_usage" {
+  description = "Flag to determine if the usage reporting Lambda function should be invoked."
+  type        = bool
+  default     = true
+}
+
+
 variable "protocol" {
   description = "Specify the protocol (NFS or ISCSI)"
   type        = string

--- a/modules/perforce/variables.tf
+++ b/modules/perforce/variables.tf
@@ -229,6 +229,7 @@ variable "p4_server_config" {
     fsxn_svm_name                     = optional(string, null)
     amazon_fsxn_svm_id                = optional(string, null)
     fsxn_aws_profile                  = optional(string, null)
+    fsxn_report_usage                 = optional(bool, true)
   })
   description = <<EOT
     # - General -


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

This pull request introduces a mechanism to optionally report usage to a monitoring Lambda function when deploying a Perforce server with FSxN storage. The changes add a new configuration flag, propagate it through module variables, and implement the Lambda invocation logic, ensuring usage is only reported when appropriate.

**Usage Reporting Enhancements:**

* Added a new `fsxn_report_usage` flag to the `p4_server_config` object and propagated it to module variables, allowing users to control whether usage reporting is enabled. 
* Implemented logic in `fsxn.tf` to invoke an AWS Lambda function for usage reporting when `fsxn_report_usage` is true and `storage_type` is `FSxN`, using a `null_resource` with a `local-exec` provisioner.
* Added a `data "aws_region" "current"` block to dynamically determine the AWS region for Lambda invocation.

### User experience

the user can ignore or enable the reporting

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change? - no</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
