### PR TITLE
fix: add required filter to s3 lifecycle rule, fix iam policy attachm…

### DIFF
--- a/modules/unreal/horde/alb.tf
+++ b/modules/unreal/horde/alb.tf
@@ -320,6 +320,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "access_logs_bucket_lifecycle_c
   rule {
     id     = "access-logs-lifecycle"
     status = "Enabled"
+    filter {}
     transition {
       days          = 30
       storage_class = "STANDARD_IA"

--- a/modules/unreal/horde/ecs.tf
+++ b/modules/unreal/horde/ecs.tf
@@ -91,7 +91,7 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.unreal_horde_log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.id
           awslogs-stream-prefix = "[APP]"
         }
       },
@@ -128,7 +128,7 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.unreal_horde_log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.id
           awslogs-stream-prefix = "[DOCDB CERT]"
         }
       },
@@ -164,7 +164,7 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.unreal_horde_log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.id
           awslogs-stream-prefix = "[P4TRUST]"
         }
       },

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -126,8 +126,8 @@ resource "aws_iam_role_policy_attachment" "unreal_horde_task_execution_policy_at
 }
 
 resource "aws_iam_role_policy_attachment" "unreal_horde_secrets_manager_policy_attachment" {
-  for_each = toset(aws_iam_policy.unreal_horde_secrets_manager_policy[*].arn)
+  count = var.github_credentials_secret_arn != null || var.p4_super_user_username_secret_arn != null ? 1 : 0
 
   role       = aws_iam_role.unreal_horde_task_execution_role.name
-  policy_arn = each.key
+  policy_arn = aws_iam_policy.unreal_horde_secrets_manager_policy[0].arn
 }


### PR DESCRIPTION
…ent, fix v6 aws provider warning

**Issue number:**
N/A
## Summary

### Changes

Fixed three Terraform issues in the Unreal Horde module:

1. **S3 lifecycle configuration**: Added required `filter {}` block to `aws_s3_bucket_lifecycle_configuration` resource
2. **Deprecated attribute**: Replaced `data.aws_region.current.name` with `data.aws_region.current.id` in ECS log configurations  
3. **Invalid for_each**: Changed IAM policy attachment from `for_each` to `count` to avoid unknown value dependency issue

### User experience

**Before**: Users encountered Terraform warnings and errors during plan/apply:
- Warning about missing filter attribute in S3 lifecycle rule
- Deprecation warnings for region data source attribute
- Error preventing deployment due to invalid for_each argument with unknown values

**After**: Clean Terraform plan/apply with no warnings or errors, allowing successful deployment of the Unreal Horde infrastructure.
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
