### PR TITLE
chore: replaces deprecated 'data.aws_region.current.name'

### DIFF
--- a/cloud-game-development-toolkit.iml
+++ b/cloud-game-development-toolkit.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/assets/jenkins-pipelines" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/modules/jenkins/ecs.tf
+++ b/modules/jenkins/ecs.tf
@@ -58,7 +58,7 @@ resource "aws_ecs_task_definition" "jenkins_task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.jenkins_service_log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = "jenkins"
         }
       }

--- a/modules/jenkins/iam.tf
+++ b/modules/jenkins/iam.tf
@@ -209,8 +209,8 @@ data "aws_iam_policy_document" "build_farm_fsxz_policy" {
       "fsx:ListTagsForResource"
     ]
     resources = concat(
-      ["arn:aws:fsx:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot/*/*"],
-      [for fs in values(aws_fsx_openzfs_file_system.jenkins_build_farm_fsxz_file_system) : "arn:aws:fsx:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/${fs.id}/*"]
+      ["arn:aws:fsx:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:snapshot/*/*"],
+      [for fs in values(aws_fsx_openzfs_file_system.jenkins_build_farm_fsxz_file_system) : "arn:aws:fsx:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:volume/${fs.id}/*"]
     )
   }
   statement {
@@ -218,14 +218,14 @@ data "aws_iam_policy_document" "build_farm_fsxz_policy" {
     actions = [
       "fsx:DescribeSnapshots"
     ]
-    resources = ["arn:aws:fsx:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:snapshot/*/*"]
+    resources = ["arn:aws:fsx:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:snapshot/*/*"]
   }
   statement {
     effect = "Allow"
     actions = [
       "fsx:DescribeVolumes"
     ]
-    resources = ["arn:aws:fsx:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:volume/*/*"]
+    resources = ["arn:aws:fsx:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:volume/*/*"]
   }
 }
 resource "aws_iam_policy" "build_farm_fsxz_policy" {

--- a/modules/perforce/examples/p4-server-fsxn/main.tf
+++ b/modules/perforce/examples/p4-server-fsxn/main.tf
@@ -55,7 +55,7 @@ provider "netapp-ontap" {
       password = var.fsxn_password
       aws_lambda = {
         function_name         = module.perforce.p4_server_lambda_link_name
-        region                = data.aws_region.current.name
+        region                = data.aws_region.current.region
         shared_config_profile = var.fsxn_aws_profile
       }
     }
@@ -99,7 +99,7 @@ module "perforce" {
     fsxn_svm_name                     = aws_fsx_ontap_storage_virtual_machine.p4_server_svm.name
     amazon_fsxn_svm_id                = aws_fsx_ontap_storage_virtual_machine.p4_server_svm.id
     fsxn_aws_profile                  = var.fsxn_aws_profile
-    fsxn_region                       = data.aws_region.current.name
+    fsxn_region                       = data.aws_region.current.region
 
     # Networking & Security
     instance_subnet_id = aws_subnet.public_subnets[0].id

--- a/modules/perforce/modules/p4-auth/main.tf
+++ b/modules/perforce/modules/p4-auth/main.tf
@@ -116,7 +116,7 @@ resource "aws_ecs_task_definition" "task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = "${local.name_prefix}-service"
         }
       }
@@ -166,7 +166,7 @@ resource "aws_ecs_task_definition" "task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = "${local.name_prefix}-service-config"
         }
       }

--- a/modules/perforce/modules/p4-code-review/main.tf
+++ b/modules/perforce/modules/p4-code-review/main.tf
@@ -75,7 +75,7 @@ resource "aws_ecs_task_definition" "task_definition" {
           logDriver = "awslogs"
           options = {
             awslogs-group         = aws_cloudwatch_log_group.log_group.name
-            awslogs-region        = data.aws_region.current.name
+            awslogs-region        = data.aws_region.current.region
             awslogs-stream-prefix = "${local.name_prefix}-service"
           }
         }
@@ -148,7 +148,7 @@ resource "aws_ecs_task_definition" "task_definition" {
           logDriver = "awslogs"
           options = {
             awslogs-group         = aws_cloudwatch_log_group.log_group.name
-            awslogs-region        = data.aws_region.current.name
+            awslogs-region        = data.aws_region.current.region
             awslogs-stream-prefix = "${local.name_prefix}-service-config"
           }
         }

--- a/modules/teamcity/agents.tf
+++ b/modules/teamcity/agents.tf
@@ -70,7 +70,7 @@ resource "aws_ecs_service" "teamcity_agent" {
       log_driver = "awslogs"
       options = {
         "awslogs-group"         = aws_cloudwatch_log_group.teamcity_agent.name
-        "awslogs-region"        = data.aws_region.current.name
+        "awslogs-region"        = data.aws_region.current.region
         "awslogs-stream-prefix" = "[AGENT - ${each.key}]"
       }
     }

--- a/modules/teamcity/main.tf
+++ b/modules/teamcity/main.tf
@@ -56,7 +56,7 @@ resource "aws_ecs_task_definition" "teamcity_task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.teamcity_log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = "[APP]"
         }
       }
@@ -153,7 +153,7 @@ resource "aws_ecs_service" "teamcity" {
       log_driver = "awslogs"
       options = {
         awslogs-group         = aws_cloudwatch_log_group.teamcity_log_group.name
-        awslogs-region        = data.aws_region.current.name
+        awslogs-region        = data.aws_region.current.region
         awslogs-stream-prefix = "[CONNECT]"
       }
     }

--- a/modules/unity/accelerator/main.tf
+++ b/modules/unity/accelerator/main.tf
@@ -172,7 +172,7 @@ resource "aws_ecs_task_definition" "unity_accelerator_task_definition" {
         logDriver = "awslogs"
         options = {
           awslogs-group         = aws_cloudwatch_log_group.unity_accelerator_log_group.name
-          awslogs-region        = data.aws_region.current.name
+          awslogs-region        = data.aws_region.current.region
           awslogs-stream-prefix = "[APP]"
         }
       }
@@ -485,7 +485,7 @@ data "aws_iam_policy_document" "cloudwatch_logs_policy" {
       "logs:DescribeLogStreams"
     ]
     resources = [
-      "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:log-group:${local.name_prefix}-log-group:*"
+      "arn:aws:logs:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:log-group:${local.name_prefix}-log-group:*"
     ]
   }
 }
@@ -779,7 +779,7 @@ resource "aws_s3_bucket_public_access_block" "access_logs_bucket_public_block" {
 resource "aws_vpc_endpoint" "ssm_vpce" {
   count               = var.debug == true ? 1 : 0
   vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ssm"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssm"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.service_subnets
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
@@ -789,7 +789,7 @@ resource "aws_vpc_endpoint" "ssm_vpce" {
 resource "aws_vpc_endpoint" "ssmmessages_vpce" {
   count               = var.debug == true ? 1 : 0
   vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ssmmessages"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ssmmessages"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.service_subnets
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]
@@ -799,7 +799,7 @@ resource "aws_vpc_endpoint" "ssmmessages_vpce" {
 resource "aws_vpc_endpoint" "ec2messages_vpce" {
   count               = var.debug == true ? 1 : 0
   vpc_id              = var.vpc_id
-  service_name        = "com.amazonaws.${data.aws_region.current.name}.ec2messages"
+  service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2messages"
   vpc_endpoint_type   = "Interface"
   subnet_ids          = var.service_subnets
   security_group_ids  = [aws_security_group.vpc_endpoint_sg[0].id]

--- a/modules/unreal/unreal-cloud-ddc/unreal-cloud-ddc-intra-cluster/helm.tf
+++ b/modules/unreal/unreal-cloud-ddc/unreal-cloud-ddc-intra-cluster/helm.tf
@@ -70,7 +70,7 @@ resource "aws_ecr_pull_through_cache_rule" "unreal_cloud_ddc_ecr_pull_through_ca
 resource "helm_release" "unreal_cloud_ddc" {
   name         = "unreal-cloud-ddc"
   chart        = "unreal-cloud-ddc"
-  repository   = "oci://${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com/github/epicgames"
+  repository   = "oci://${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/github/epicgames"
   namespace    = var.unreal_cloud_ddc_namespace
   version      = "${var.unreal_cloud_ddc_version}+helm"
   reset_values = true

--- a/samples/unreal-cloud-ddc-single-region/main.tf
+++ b/samples/unreal-cloud-ddc-single-region/main.tf
@@ -84,7 +84,7 @@ module "unreal_cloud_ddc_infra" {
   depends_on = [module.unreal_cloud_ddc_vpc]
   source     = "../../modules/unreal/unreal-cloud-ddc/unreal-cloud-ddc-infra"
   name       = "unreal-cloud-ddc"
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
   vpc_id     = module.unreal_cloud_ddc_vpc.vpc_id
 
   eks_node_group_subnets                  = module.unreal_cloud_ddc_vpc.private_subnet_ids
@@ -131,8 +131,8 @@ module "unreal_cloud_ddc_intra_cluster" {
     templatefile("${path.module}/assets/unreal_cloud_ddc_single_region.yaml", {
       scylla_ips         = "${module.unreal_cloud_ddc_infra.scylla_ips[0]},${module.unreal_cloud_ddc_infra.scylla_ips[1]}"
       bucket_name        = module.unreal_cloud_ddc_infra.s3_bucket_id
-      region             = substr(data.aws_region.current.name, length(data.aws_region.current.name) - 1, 1) == "1" ? substr(data.aws_region.current.name, 0, length(data.aws_region.current.name) - 2) : data.aws_region.current.name
-      aws_region         = data.aws_region.current.name
+      region             = substr(data.aws_region.current.region, length(data.aws_region.current.region) - 1, 1) == "1" ? substr(data.aws_region.current.region, 0, length(data.aws_region.current.region) - 2) : data.aws_region.current.region
+      aws_region         = data.aws_region.current.region
       security_group_ids = aws_security_group.unreal_ddc_load_balancer_access_security_group.id
       token              = data.aws_secretsmanager_secret_version.unreal_cloud_ddc_token.secret_string
     })

--- a/samples/unreal-cloud-ddc-single-region/providers.tf
+++ b/samples/unreal-cloud-ddc-single-region/providers.tf
@@ -52,7 +52,7 @@ provider "helm" {
     }
   }
   registry {
-    url      = "oci://${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.name}.amazonaws.com"
+    url      = "oci://${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com"
     username = data.aws_ecr_authorization_token.token.user_name
     password = data.aws_ecr_authorization_token.token.password
   }

--- a/samples/unreal-cloud-ddc-single-region/vpc/main.tf
+++ b/samples/unreal-cloud-ddc-single-region/vpc/main.tf
@@ -138,5 +138,5 @@ resource "aws_nat_gateway" "nat_gateway" {
 
 resource "aws_vpc_endpoint" "s3" {
   vpc_id       = aws_vpc.unreal_cloud_ddc_vpc.id
-  service_name = "com.amazonaws.${data.aws_region.current.name}.s3"
+  service_name = "com.amazonaws.${data.aws_region.current.region}.s3"
 }


### PR DESCRIPTION
**Issue number:** N/A

## Summary
Replaces all instances of `data.aws_region.current.**name**` with `data.aws_region.current.**region**` to address deprecation warning.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
no
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
