### PR TITLE
fix(teamcity): service connect with external clusters and add arbitrary env var support

### DIFF
--- a/modules/teamcity/README.md
+++ b/modules/teamcity/README.md
@@ -7,6 +7,47 @@ The TeamCity server relies on shared file system for persistent storage of confi
 ## Deployment Architecture
 ![TeamCity Module Architecture](./assets/media/diagrams/teamcity-server-architecture.png)
 
+## Build Agent Configuration
+
+### Custom Environment Variables
+
+Build agents can be configured with custom environment variables through the `build_farm_config` variable. This allows you to pass non-sensitive configuration data such as service endpoints, feature flags, or other runtime settings to your build agents.
+
+Each build agent configuration supports an optional `environment` map where you can define key-value pairs that will be injected as environment variables into the agent container:
+
+```hcl
+module "teamcity" {
+  source = "path/to/teamcity/module"
+
+  # ... other configuration ...
+
+  build_farm_config = {
+    "my-build-agent" = {
+      image         = "my-registry/my-build-agent:latest"
+      cpu           = 2048
+      memory        = 4096
+      desired_count = 2
+
+      # Custom environment variables for non-sensitive configuration
+      environment = {
+        UNITY_LICENSE_SERVER_URL = "http://unity-license-server:8080"
+        BUILD_CACHE_BUCKET       = "my-build-cache-bucket"
+        CUSTOM_API_ENDPOINT      = "https://api.example.com"
+        ENABLE_DEBUG_LOGGING     = "true"
+      }
+    }
+  }
+}
+```
+
+The module automatically injects the following default environment variables into all build agents:
+- `SERVER_URL`: The TeamCity server URL for agent registration
+- `AGENT_NAME`: The name of the agent instance
+
+Any custom environment variables you provide will be merged with these defaults, allowing you to extend the agent configuration without overriding essential settings.
+
+**Security Note**: Do not pass sensitive data such as passwords, API keys, or tokens through environment variables. Use AWS Secrets Manager or IAM roles for secure credential management.
+
 ## Examples
 
 For example configurations, please see the [examples](https://github.com/aws-games/cloud-game-development-toolkit/tree/main/modules/teamcity/examples).
@@ -104,7 +145,7 @@ No modules.
 | <a name="input_alb_subnets"></a> [alb\_subnets](#input\_alb\_subnets) | The subnets in which the ALB will be deployed | `list(string)` | `[]` | no |
 | <a name="input_aurora_instance_count"></a> [aurora\_instance\_count](#input\_aurora\_instance\_count) | Number of instances to provision for the Aurora cluster | `number` | `2` | no |
 | <a name="input_aurora_skip_final_snapshot"></a> [aurora\_skip\_final\_snapshot](#input\_aurora\_skip\_final\_snapshot) | Flag for whether a final snapshot should be created when the cluster is destroyed. | `bool` | `true` | no |
-| <a name="input_build_farm_config"></a> [build\_farm\_config](#input\_build\_farm\_config) | n/a | <pre>map(object({<br>    image         = string<br>    desired_count = number<br>    cpu           = number<br>    memory        = number<br>  }))</pre> | `{}` | no |
+| <a name="input_build_farm_config"></a> [build\_farm\_config](#input\_build\_farm\_config) | Map of build agent configurations where each key is the agent name and the value defines:<br/>- image: Container image for the build agent<br/>- desired\_count: Number of agent instances to run<br/>- cpu: CPU units to allocate (1024 = 1 vCPU)<br/>- memory: Memory in MiB to allocate<br/>- environment: Optional map of custom environment variables for non-sensitive configuration<br/>- ephemeral\_storage\_gib: Optional ephemeral storage size in GiB (defaults to 20 GiB) | <pre>map(object({<br/>    image                 = string<br/>    desired_count         = number<br/>    cpu                   = number<br/>    memory                = number<br/>    environment           = optional(map(string), {})<br/>    ephemeral_storage_gib = optional(number, 20)<br/>  }))</pre> | `{}` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the ECS cluster to deploy TeamCity to. | `string` | `null` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | The number of CPU units to allocate to the TeamCity server container | `number` | `1024` | no |
 | <a name="input_container_memory"></a> [container\_memory](#input\_container\_memory) | The number of MB of memory to allocate to the TeamCity server container | `number` | `4096` | no |
@@ -124,7 +165,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The current environment (e.g. dev, prod, etc.) | `string` | `"dev"` | no |
 | <a name="input_name"></a> [name](#input\_name) | The name applied to resources in the TeamCity module | `string` | `"teamcity"` | no |
 | <a name="input_service_subnets"></a> [service\_subnets](#input\_service\_subnets) | The subnets in which the TeamCity server service will be deployed | `list(string)` | n/a | yes |
-| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br>  "iac-management": "CGD-Toolkit",<br>  "iac-module": "TeamCity",<br>  "iac-provider": "Terraform"<br>}</pre> | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br/>  "iac-management": "CGD-Toolkit",<br/>  "iac-module": "TeamCity",<br/>  "iac-provider": "Terraform"<br/>}</pre> | no |
 | <a name="input_teamcity_alb_access_logs_bucket"></a> [teamcity\_alb\_access\_logs\_bucket](#input\_teamcity\_alb\_access\_logs\_bucket) | ID of the S3 bucket for TeamCity ALB access log storage. If access logging is enabled and this is null the module creates a bucket. | `string` | `null` | no |
 | <a name="input_teamcity_alb_access_logs_prefix"></a> [teamcity\_alb\_access\_logs\_prefix](#input\_teamcity\_alb\_access\_logs\_prefix) | Log prefix for TeamCity ALB access logs. If null the project prefix and module name are used. | `string` | `null` | no |
 | <a name="input_teamcity_cloudwatch_log_retention_in_days"></a> [teamcity\_cloudwatch\_log\_retention\_in\_days](#input\_teamcity\_cloudwatch\_log\_retention\_in\_days) | The log retention in days of the cloudwatch log group for TeamCity. | `string` | `365` | no |

--- a/modules/teamcity/local.tf
+++ b/modules/teamcity/local.tf
@@ -40,6 +40,9 @@ locals {
       value = local.database_master_password
     }
   ] : []
+
+  # Service Connect namespace
+  service_connect_namespace_arn = aws_service_discovery_http_namespace.teamcity.arn
 }
 data "aws_region" "current" {}
 

--- a/modules/teamcity/outputs.tf
+++ b/modules/teamcity/outputs.tf
@@ -14,6 +14,6 @@ output "security_group_id" {
 }
 
 output "teamcity_cluster_id" {
-  value       = aws_ecs_cluster.teamcity_cluster[0].id
+  value       = var.cluster_name != null ? data.aws_ecs_cluster.teamcity_cluster[0].id : aws_ecs_cluster.teamcity_cluster[0].id
   description = "The ID of the ECS cluster"
 }

--- a/modules/teamcity/variables.tf
+++ b/modules/teamcity/variables.tf
@@ -232,12 +232,23 @@ variable "aurora_instance_count" {
 
 variable "build_farm_config" {
   type = map(object({
-    image         = string
-    desired_count = number
-    cpu           = number
-    memory        = number
+    image                 = string
+    desired_count         = number
+    cpu                   = number
+    memory                = number
+    environment           = optional(map(string), {})
+    ephemeral_storage_gib = optional(number, 20)
   }))
-  default = {}
+  default     = {}
+  description = <<-EOT
+    Map of build agent configurations where each key is the agent name and the value defines:
+    - image: Container image for the build agent
+    - desired_count: Number of agent instances to run
+    - cpu: CPU units to allocate (1024 = 1 vCPU)
+    - memory: Memory in MiB to allocate
+    - environment: Optional map of custom environment variables for non-sensitive configuration
+    - ephemeral_storage_gib: Optional ephemeral storage size in GiB (defaults to 20 GiB)
+  EOT
 }
 
 variable "agent_log_group_retention_in_days" {


### PR DESCRIPTION
**Issue number:** N/A

## Summary

This PR fixes critical bugs in the TeamCity module's Service Connect configuration when using external ECS clusters and adds support for custom environment variables in build agent configurations. It also increases ephemeral storage for build agents to accommodate larger build workloads.

  - Fix Service Connect namespace to work with external ECS clusters by making it always created
  - Use dynamic block for service_connect_defaults to conditionally set namespace
  - Add local variable for service_connect_namespace_arn to simplify references
  - Fix teamcity_cluster_id output to handle both created and external clusters
  - Add support for injecting custom environment variables into the build agents through build_farm_config
  - Increase ephemeral storage from 20GB to 50GB for build agents

### Changes

This PR includes bug fixes and enhancements to the TeamCity module:

**Bug Fixes:**
- Fixed Service Connect namespace creation when using external ECS clusters. Previously, the namespace resource had a `count` condition that prevented it from being created when `cluster_name` was provided, causing agent-to-server communication to fail.
- Fixed `service_connect_defaults` block to only be set when creating a new cluster (not when using an external one)
- Fixed `teamcity_cluster_id` output to correctly return either the created or external cluster ID

**Enhancements:**
- Added support for custom environment variables in `build_farm_config` via an optional `environment` map, making the module more flexible for different build agent configurations
- Increased ephemeral storage from default 20GB to 50GB for build agents to accommodate larger build workloads (e.g., Unity builds)
- Added `service_connect_namespace_arn` local variable to simplify namespace references throughout the module

### User experience

**Before:**
- Users could not use the TeamCity module with an external ECS cluster because Service Connect namespace wasn't created, causing agents to fail connecting to the TeamCity server
- Build agents had limited storage (20GB) which was insufficient for large builds
- Users could not pass custom environment variables to build agents, limiting flexibility

**After:**
- TeamCity module works correctly with both self-managed and external ECS clusters
- Build agents have 50GB of ephemeral storage, sufficient for Unity and other large builds
- Users can pass arbitrary environment variables to specific build agent configurations through the `environment` map in `build_farm_config`

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**No**, this is not a breaking change. All changes are backward compatible:
 - The `environment` field in `build_farm_config` is optional with a default of `{}`
 - Existing configurations will continue to work without modification
 - The Service Connect namespace changes fix bugs without altering the module's interface

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.