### PR TITLE
chore(unity-floating-license-server): add private IP output

### DIFF
--- a/modules/unity/floating-license-server/README.md
+++ b/modules/unity/floating-license-server/README.md
@@ -139,6 +139,7 @@ No modules.
 | <a name="output_created_unity_license_server_security_group_id"></a> [created\_unity\_license\_server\_security\_group\_id](#output\_created\_unity\_license\_server\_security\_group\_id) | Id of the security group created by the script, for the Unity License Server instance. Null if an ENI was provided externally instead of created through the script. |
 | <a name="output_dashboard_password_secret_arn"></a> [dashboard\_password\_secret\_arn](#output\_dashboard\_password\_secret\_arn) | ARN of the secret containing the dashboard password. |
 | <a name="output_eni_id"></a> [eni\_id](#output\_eni\_id) | Elastic Network ID (ENI) used when binding the Unity Floating License Server. |
+| <a name="output_instance_private_ip"></a> [instance\_private\_ip](#output\_instance\_private\_ip) | The EC2 instance's private IP address. |
 | <a name="output_instance_public_ip"></a> [instance\_public\_ip](#output\_instance\_public\_ip) | The resulting EC2 instance's public IP, if configured. |
 | <a name="output_registration_request_filename"></a> [registration\_request\_filename](#output\_registration\_request\_filename) | Filename for the server registration request file. |
 | <a name="output_registration_request_presigned_url"></a> [registration\_request\_presigned\_url](#output\_registration\_request\_presigned\_url) | Presigned URL for downloading the server registration request file (valid for 1 hour). |

--- a/modules/unity/floating-license-server/outputs.tf
+++ b/modules/unity/floating-license-server/outputs.tf
@@ -8,6 +8,11 @@ output "instance_public_ip" {
   value       = aws_instance.unity_license_server.public_ip
 }
 
+output "instance_private_ip" {
+  description = "The EC2 instance's private IP address."
+  value       = aws_instance.unity_license_server.private_ip
+}
+
 output "alb_dns_name" {
   description = "DNS endpoint of Application Load Balancer (ALB)."
   value       = var.create_alb ? aws_lb.unity_license_server_alb[0].dns_name : null


### PR DESCRIPTION
**Issue number:** N/A

## Summary

This PR adds a new output to the Unity Floating License Server module that exposes the EC2 instance's private IP address, enabling automated configuration of internal services that need to communicate with
the license server.

### Changes

- Added `instance_private_ip` output that returns the EC2 instance's private IP address
- Updated module README documentation

### User experience

**Before:**
- Users had to manually retrieve the license server's private IP from the EC2 console or use AWS CLI commands to configure services that communicate with the license server
- No direct way to reference the private IP in Terraform configurations

**After:**
- The license server's private IP is automatically available as a module output
- Users can programmatically reference the private IP in their Terraform configurations (e.g., `module.unity_license_server.instance_private_ip`)
- Enables automated configuration of build agents and other services that need to connect to the license server over the private network

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

**No**, this is not a breaking change. This only adds a new output without modifying any existing functionality or module interface.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.