### PR TITLE
fix(teamcity): service connect namespace for external clusters and add custom env vars

### DIFF
--- a/modules/teamcity/README.md
+++ b/modules/teamcity/README.md
@@ -7,6 +7,47 @@ The TeamCity server relies on shared file system for persistent storage of confi
 ## Deployment Architecture
 ![TeamCity Module Architecture](./assets/media/diagrams/teamcity-server-architecture.png)
 
+## Build Agent Configuration
+
+### Custom Environment Variables
+
+Build agents can be configured with custom environment variables through the `build_farm_config` variable. This allows you to pass non-sensitive configuration data such as service endpoints, feature flags, or other runtime settings to your build agents.
+
+Each build agent configuration supports an optional `environment` map where you can define key-value pairs that will be injected as environment variables into the agent container:
+
+```hcl
+module "teamcity" {
+  source = "path/to/teamcity/module"
+
+  # ... other configuration ...
+
+  build_farm_config = {
+    "my-build-agent" = {
+      image         = "my-registry/my-build-agent:latest"
+      cpu           = 2048
+      memory        = 4096
+      desired_count = 2
+
+      # Custom environment variables for non-sensitive configuration
+      environment = {
+        UNITY_LICENSE_SERVER_URL = "http://unity-license-server:8080"
+        BUILD_CACHE_BUCKET       = "my-build-cache-bucket"
+        CUSTOM_API_ENDPOINT      = "https://api.example.com"
+        ENABLE_DEBUG_LOGGING     = "true"
+      }
+    }
+  }
+}
+```
+
+The module automatically injects the following default environment variables into all build agents:
+- `SERVER_URL`: The TeamCity server URL for agent registration
+- `AGENT_NAME`: The name of the agent instance
+
+Any custom environment variables you provide will be merged with these defaults, allowing you to extend the agent configuration without overriding essential settings.
+
+**Security Note**: Do not pass sensitive data such as passwords, API keys, or tokens through environment variables. Use AWS Secrets Manager or IAM roles for secure credential management.
+
 ## Examples
 
 For example configurations, please see the [examples](https://github.com/aws-games/cloud-game-development-toolkit/tree/main/modules/teamcity/examples).
@@ -104,7 +145,7 @@ No modules.
 | <a name="input_alb_subnets"></a> [alb\_subnets](#input\_alb\_subnets) | The subnets in which the ALB will be deployed | `list(string)` | `[]` | no |
 | <a name="input_aurora_instance_count"></a> [aurora\_instance\_count](#input\_aurora\_instance\_count) | Number of instances to provision for the Aurora cluster | `number` | `2` | no |
 | <a name="input_aurora_skip_final_snapshot"></a> [aurora\_skip\_final\_snapshot](#input\_aurora\_skip\_final\_snapshot) | Flag for whether a final snapshot should be created when the cluster is destroyed. | `bool` | `true` | no |
-| <a name="input_build_farm_config"></a> [build\_farm\_config](#input\_build\_farm\_config) | n/a | <pre>map(object({<br/>    image         = string<br/>    desired_count = number<br/>    cpu           = number<br/>    memory        = number<br/>  }))</pre> | `{}` | no |
+| <a name="input_build_farm_config"></a> [build\_farm\_config](#input\_build\_farm\_config) | Map of build agent configurations where each key is the agent name and the value defines:<br/>- image: Container image for the build agent<br/>- desired\_count: Number of agent instances to run<br/>- cpu: CPU units to allocate (1024 = 1 vCPU)<br/>- memory: Memory in MiB to allocate<br/>- environment: Optional map of custom environment variables for non-sensitive configuration<br/>- ephemeral\_storage\_gib: Optional ephemeral storage size in GiB (defaults to 20 GiB) | <pre>map(object({<br/>    image                 = string<br/>    desired_count         = number<br/>    cpu                   = number<br/>    memory                = number<br/>    environment           = optional(map(string), {})<br/>    ephemeral_storage_gib = optional(number, 20)<br/>  }))</pre> | `{}` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the ECS cluster to deploy TeamCity to. | `string` | `null` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | The number of CPU units to allocate to the TeamCity server container | `number` | `1024` | no |
 | <a name="input_container_memory"></a> [container\_memory](#input\_container\_memory) | The number of MB of memory to allocate to the TeamCity server container | `number` | `4096` | no |

--- a/modules/teamcity/local.tf
+++ b/modules/teamcity/local.tf
@@ -40,6 +40,9 @@ locals {
       value = local.database_master_password
     }
   ] : []
+
+  # Service Connect namespace
+  service_connect_namespace_arn = aws_service_discovery_http_namespace.teamcity.arn
 }
 data "aws_region" "current" {}
 

--- a/modules/teamcity/outputs.tf
+++ b/modules/teamcity/outputs.tf
@@ -14,6 +14,6 @@ output "security_group_id" {
 }
 
 output "teamcity_cluster_id" {
-  value       = aws_ecs_cluster.teamcity_cluster[0].id
+  value       = var.cluster_name != null ? data.aws_ecs_cluster.teamcity_cluster[0].id : aws_ecs_cluster.teamcity_cluster[0].id
   description = "The ID of the ECS cluster"
 }

--- a/modules/teamcity/variables.tf
+++ b/modules/teamcity/variables.tf
@@ -232,12 +232,23 @@ variable "aurora_instance_count" {
 
 variable "build_farm_config" {
   type = map(object({
-    image         = string
-    desired_count = number
-    cpu           = number
-    memory        = number
+    image                 = string
+    desired_count         = number
+    cpu                   = number
+    memory                = number
+    environment           = optional(map(string), {})
+    ephemeral_storage_gib = optional(number, 20)
   }))
-  default = {}
+  default     = {}
+  description = <<-EOT
+    Map of build agent configurations where each key is the agent name and the value defines:
+    - image: Container image for the build agent
+    - desired_count: Number of agent instances to run
+    - cpu: CPU units to allocate (1024 = 1 vCPU)
+    - memory: Memory in MiB to allocate
+    - environment: Optional map of custom environment variables for non-sensitive configuration
+    - ephemeral_storage_gib: Optional ephemeral storage size in GiB (defaults to 20 GiB)
+  EOT
 }
 
 variable "agent_log_group_retention_in_days" {


### PR DESCRIPTION
**Issue number:** N/A

## Summary

This PR fixes a bug in Service Connect namespace configuration when using externally-managed ECS clusters and adds support for customizable build agent configuration.

**Bug Fix**: Previously, the Service Connect namespace ARN was always referenced from the module-created cluster, causing errors when users provided an external cluster via `cluster_name`. The namespace ARN
now correctly references the appropriate cluster (external or module-created).

**Enhancements**: Build agents now support custom environment variables for non-sensitive configuration and configurable ephemeral storage to accommodate different build workload requirements.

### Changes

This PR fixes a bug where the Service Connect namespace wasn't created when using an external ECS cluster, causing service discovery to fail. It also adds support for custom environment variables and
configurable ephemeral storage for build agents.

**Bug Fixes:**
- Service Connect namespace is now always created, regardless of whether an external cluster is provided
- The `service_connect_defaults` block is now conditionally applied only when the module creates its own cluster
- Fixed `teamcity_cluster_id` output to correctly return the cluster ID for both scenarios

**Enhancements:**
- Build agents can now receive custom environment variables via the `environment` map in `build_farm_config` for non-sensitive configuration like service endpoints and feature flags
- Ephemeral storage size is now configurable per agent via `ephemeral_storage_gib` parameter (defaults to 20 GiB)
- Added "Build Agent Configuration" section to README with security guidance

### User experience

**Before:**
- Using an external ECS cluster would result in Service Connect failures due to missing namespace
- Build agents had hardcoded 50 GiB ephemeral storage with no way to customize
- No way to pass configuration to build agents without rebuilding container images

**After:**
- Service Connect works correctly with both module-created and external ECS clusters
- Build agents can receive custom environment variables for configuration (e.g., license server URLs, API endpoints)
- Ephemeral storage size is configurable per agent type with sensible 20 GiB default
- README provides clear documentation on how to use custom environment variables safely

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

No - all enhancements use optional parameters with backward-compatible defaults.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.