### PR TITLE
fix(unity-license-server): use traffic-port for health check

### DIFF
--- a/modules/unity/floating-license-server/alb.tf
+++ b/modules/unity/floating-license-server/alb.tf
@@ -71,7 +71,7 @@ resource "aws_lb_target_group" "unity_license_server_tg" {
     timeout             = 5
     healthy_threshold   = 5
     unhealthy_threshold = 2
-    port                = 80
+    port                = "traffic-port"
     protocol            = "HTTP"
     matcher             = "200"
   }


### PR DESCRIPTION
**Issue number:** NA

## Summary

Health check was hardcoded to port 80 instead of using the target group's traffic port, causing targets to fail health checks.

### Changes

Changes the port used for the ALB health check from 80 to "traffic-port"

### User experience

Instances of the unity license server will no longer show as not healthy despite being healthy.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
 No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
