### PR TITLE
fix(ci): optimize pre-commit workflow to prevent disk space errors

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,13 +5,60 @@ permissions: read-all
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    env:
+      # Share Terraform providers across all terraform init calls to reduce disk usage
+      TF_PLUGIN_CACHE_DIR: ${{ github.workspace }}/.terraform-plugin-cache
     steps:
+      - name: Free up disk space
+        # Remove pre-installed tools not needed for pre-commit hooks
+        # This prevents "no space left on device" errors during terraform init
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          echo "Disk space after cleanup:"
+          df -h
+
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - uses: hashicorp/setup-terraform@v3
       - uses: terraform-linters/setup-tflint@v6
+
+      - name: Create Terraform plugin cache directory
+        run: mkdir -p $TF_PLUGIN_CACHE_DIR
+
+      - name: Generate hash of all versions.tf files
+        id: versions-hash
+        run: |
+          # Create a hash of all versions.tf files to use as cache key
+          HASH=$(find . -name "versions.tf" -not -path "*/.terraform/*" -not -path "*/.external_modules/*" -type f -exec sha256sum {} \; | sort | sha256sum | cut -d' ' -f1)
+          echo "hash=$HASH" >> $GITHUB_OUTPUT
+          echo "Versions hash: $HASH"
+
+      - name: Cache Terraform lock files
+        uses: actions/cache@v4
+        id: lock-files-cache
+        with:
+          path: "**/.terraform.lock.hcl"
+          key: terraform-lock-files-${{ steps.versions-hash.outputs.hash }}
+
+      - name: Generate lock files for CI environment
+        if: steps.lock-files-cache.outputs.cache-hit != 'true'
+        # Generate .terraform.lock.hcl files with linux_amd64 checksums for all modules
+        # This allows the plugin cache to work while keeping lock files out of the repo
+        run: |
+          echo "Generating lock files for all Terraform modules..."
+          find . -name "versions.tf" -not -path "*/.terraform/*" -not -path "*/.external_modules/*" | while read -r versions_file; do
+            dir=$(dirname "$versions_file")
+            echo "Processing: $dir"
+            (cd "$dir" && terraform init -backend=false && terraform providers lock -platform=linux_amd64) || echo "Failed to generate lock file for $dir"
+          done
+          echo "Lock file generation complete"
 
       - name: terraform-docs alias
         # This is necessary because terraform docs doesn't install super duper easily


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

Fixed the pre-commit GitHub Actions workflow failing with "no space left on device" errors during `terraform init` commands. The workflow runs `terraform init` across 25+ modules and examples, each
downloading large Terraform providers separately, causing disk exhaustion.

**Optimizations implemented:**

1. **Disk Space Cleanup**: Removes pre-installed tools not needed for pre-commit hooks (.NET SDK, Android SDK, Haskell compiler, CodeQL tools), freeing up ~14GB of disk space

2. **Terraform Plugin Cache**: Added `TF_PLUGIN_CACHE_DIR` environment variable to share downloaded providers across all `terraform init` calls, eliminating redundant downloads and saving ~9GB

3. **Dynamic Lock File Generation**: Generates `.terraform.lock.hcl` files with linux_amd64 checksums in CI before pre-commit runs, enabling plugin cache to work while keeping lock files out of the repository
 (preserving module flexibility for users)

4. **Lock File Caching**: Caches generated lock files based on a hash of all `versions.tf` files, dramatically reducing workflow time on subsequent runs when provider versions haven't changed

5. **Disk Usage Reporting**: Added `df -h` output before and after cleanup for visibility into disk space availability

### User experience

**Before:**
The pre-commit workflow failed with "no space left on device" errors when attempting to download and install Terraform providers. Workflows started with 22GB available and ran out of space at 36MB. PRs would
show failed checks, requiring manual investigation and re-runs.

**After:**
The pre-commit workflow completes successfully with 36GB available disk space after cleanup. Terraform providers are downloaded once and reused across all modules via the plugin cache. Lock files are
generated dynamically in CI based on the current `versions.tf` files and cached for reuse on subsequent runs.

**Performance improvements:**
- First run: ~5 minutes for lock file generation + normal pre-commit time
- Subsequent runs: ~1 second to restore cached lock files + normal pre-commit time
- Total space optimization: ~23GB freed/saved

Contributors see passing pre-commit checks without disk space failures, and the repository remains generic with users managing their own lock files locally.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

No, this is not a breaking change. This only modifies the GitHub Actions workflow environment setup and does not affect any code, modules, or how users interact with the repository. Lock files remain
gitignored, preserving the repository's flexibility as a reusable module library.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.