### PR TITLE
ci: conditionally remove commenting for PRs from forks

### DIFF
--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -7,7 +7,6 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
   pull-requests: write
 
@@ -54,7 +53,6 @@ jobs:
     needs: detect-changes
     if: needs.detect-changes.outputs.test_dirs != '[]'
     runs-on: ubuntu-latest
-    environment: aws-ci
     strategy:
       matrix:
         module: ${{ fromJson(needs.detect-changes.outputs.test_dirs) }}
@@ -65,12 +63,6 @@ jobs:
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: "1.14.2"
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v5.1.1
-        with:
-          role-to-assume: ${{ secrets.AWS_CI_ROLE_ARN }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
 
       - name: Check for tests
         id: check-tests
@@ -96,7 +88,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Comment on PR
-        if: failure() && github.event_name == 'pull_request'
+        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -104,7 +104,7 @@ jobs:
           terraform validate
 
       - name: Comment on PR
-        if: failure() && github.event_name == 'pull_request'
+        if: failure() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v8
         with:
           script: |


### PR DESCRIPTION
**Issue number:**
N/A

## Summary

Modified the Terraform testing and validation workflows to only comment on PRs in this repository. This resolves permissions issues with commenting on PRs from forked repositories.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
