### PR TITLE
fix(p4): bump ebs volume mounting retry count

### DIFF
--- a/assets/packer/perforce/p4-server/p4_configure.sh
+++ b/assets/packer/perforce/p4-server/p4_configure.sh
@@ -541,10 +541,11 @@ perform_operations() {
 
 
 # Maximum number of attempts (added due to terraform not mounting EBS fast enough at instance boot)
-MAX_ATTEMPTS=3
+MAX_ATTEMPTS=5
 
 # Counter for attempts
 attempt=1
+delay=1
 
 # Flag to track if the condition is met
 condition_met=false
@@ -558,7 +559,8 @@ while [ $attempt -le $MAX_ATTEMPTS ] && [ "$condition_met" = false ]; do
         perform_operations
     else
         log_message "Attempt $attempt: One or more required paths are not valid EBS volumes or FSx mount points."
-        sleep 5  # Wait for 1 second before the next attempt
+        sleep "$delay"  # Wait before the next attempt
+        delay=$((delay * 2))
         ((attempt++))
     fi
 done


### PR DESCRIPTION
## Summary

We were seeing failures occasionally as the volumes weren't mounted in time.

### Changes

Bump EBS mount attempts from 3 to 100 to allow for slower mounts.

### User experience

Startup times may be slower in the failure case, but will be more resilient to slow boots.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
