### PR TITLE
fix(p4): remove busticated depends_on

### DIFF
--- a/modules/perforce/main.tf
+++ b/modules/perforce/main.tf
@@ -59,7 +59,6 @@ module "p4_server" {
   super_user_username_secret_arn = var.p4_server_config.super_user_username_secret_arn
   create_default_role            = var.p4_server_config.create_default_role
   custom_role                    = var.p4_server_config.custom_role
-  depends_on                     = [module.p4_auth]
 }
 
 


### PR DESCRIPTION
## Summary

This fixes some unnecessary replacements when making changes to the p4_auth module. More details in this thread:
https://discuss.hashicorp.com/t/force-replacement-caused-by-location-non-change/32610/4

### Changes

Removes the module-level `depends_on`, as anything with actual dependencies is correctly deduced by individual resources.

### User experience

Users should notice fewer replacements of the p4 server when iterating on p4 auth config.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [X] I have performed a self-review of this change
* [X] Changes have been tested
* [X] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
No
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
