### PR TITLE
ci: Create issues on docs workflow failure

### DIFF
--- a/.github/workflows/docs-deploy-latest.yml
+++ b/.github/workflows/docs-deploy-latest.yml
@@ -37,7 +37,6 @@ jobs:
       issues: write
     with:
       scope: "changed"
-      fail_on_error: true
       create_issue: false
 
   deploy:

--- a/.github/workflows/docs-deploy-version.yml
+++ b/.github/workflows/docs-deploy-version.yml
@@ -36,7 +36,6 @@ jobs:
       issues: write
     with:
       scope: "all"
-      fail_on_error: true
       create_issue: false
 
   deploy:

--- a/.github/workflows/docs-health-check.yml
+++ b/.github/workflows/docs-health-check.yml
@@ -1,19 +1,8 @@
 name: Documentation Health Check
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "**/README.md"
-      - "CHANGELOG.md"
-      - "CONTRIBUTING.md"
-      - ".config/lychee.toml"
-      - ".config/.markdownlint-cli2.jsonc"
   schedule:
-    # Run weekly on Mondays at 9am UTC
+    # Run weekly on Mondays at 9am UTC to catch link rot and regressions
     - cron: "0 9 * * 1"
   workflow_dispatch:
 
@@ -30,5 +19,4 @@ jobs:
       issues: write
     with:
       scope: "all"
-      fail_on_error: false
       create_issue: true

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -43,7 +43,6 @@ jobs:
       issues: write
     with:
       scope: "changed"
-      fail_on_error: true
       create_issue: false
 
   check-changes:

--- a/.github/workflows/docs-validate.yml
+++ b/.github/workflows/docs-validate.yml
@@ -8,11 +8,6 @@ on:
         required: false
         type: string
         default: "changed"
-      fail_on_error:
-        description: "Whether to fail the workflow on validation errors"
-        required: false
-        type: boolean
-        default: true
       create_issue:
         description: "Whether to create a GitHub issue on validation failure"
         required: false
@@ -49,10 +44,9 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --config .config/lychee.toml --no-progress ${{ steps.changed-files.outputs.all_changed_files }}
-          fail: ${{ inputs.fail_on_error }}
+          fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: ${{ !inputs.fail_on_error }}
 
       - name: Check all links
         if: inputs.scope == 'all'
@@ -60,10 +54,9 @@ jobs:
         uses: lycheeverse/lychee-action@v2
         with:
           args: --config .config/lychee.toml --no-progress '**/*.md' '**/*.html'
-          fail: ${{ inputs.fail_on_error }}
+          fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: ${{ !inputs.fail_on_error }}
 
       - name: Set link check outcome
         id: link-outcome
@@ -101,7 +94,6 @@ jobs:
           config: ".config/.markdownlint-cli2.jsonc"
           globs: |
             ${{ steps.changed-files.outputs.all_changed_files }}
-        continue-on-error: ${{ !inputs.fail_on_error }}
 
       - name: Lint all markdown files
         if: inputs.scope == 'all'
@@ -110,7 +102,6 @@ jobs:
         with:
           config: ".config/.markdownlint-cli2.jsonc"
           globs: "**/*.md"
-        continue-on-error: ${{ !inputs.fail_on_error }}
 
       - name: Set lint outcome
         id: lint-outcome
@@ -143,7 +134,6 @@ jobs:
         run: |
           pip install -r docs/requirements.txt
           mkdocs build --strict
-        continue-on-error: ${{ !inputs.fail_on_error }}
 
   create-issue:
     name: Create Issue on Failure


### PR DESCRIPTION
## 🐛 Fix: Documentation Workflow Issue Creation

This PR fixes a critical bug where the documentation health check workflow wasn't creating GitHub issues when validation failures were detected.

### Problem

After merging the initial documentation automation PR (#820), we discovered that the health check workflow was finding validation errors but **not creating GitHub issues** as intended.

**Root Cause:** The `continue-on-error` directive caused validation jobs to always report as "success" even when steps failed. The `create-issue` job condition checked for `result == 'failure'`, which never triggered.

### Changes Made

#### **1. Removed `continue-on-error` Logic**

- Removed `continue-on-error` from link checking steps
- Removed `continue-on-error` from markdown linting steps  
- Removed `continue-on-error` from build step
- Jobs now fail naturally when validation finds errors

#### **2. Removed `fail_on_error` Parameter**

- Deleted `fail_on_error` input from `docs-validate.yml`
- Removed all references to this parameter from caller workflows:
  - `docs-preview.yml`
  - `docs-deploy-latest.yml`
  - `docs-deploy-version.yml`
  - `docs-health-check.yml`
- Simplified validation logic (failures always fail the job)

#### **3. Optimized Health Check Triggers**

- Removed `push` trigger from `docs-health-check.yml`
- Health check now only runs:
  - **Weekly** on Mondays at 9am UTC (catch link rot)
  - **Manual** via `workflow_dispatch`
- Eliminates redundant validation on main branch merges

### How It Works Now

**Before:**
```yaml
continue-on-error: ${{ !inputs.fail_on_error }}
# Jobs always reported as "success" → no issues created
```

**After:**
```yaml
# No continue-on-error
# Jobs fail naturally → create-issue job runs (if: always()) → issues created ✅
```

### Impact

**PR Workflows:**
- Validation fails → Job fails → **Blocks merge** ✅
- No change in behavior (already worked correctly)

**Main Branch Merges:**
- `docs-deploy-latest.yml` validates and deploys (no change)
- `docs-health-check.yml` no longer runs on push (optimization)
- **50% reduction in validation runs** on main branch

**Health Check (Scheduled/Manual):**
- Validation fails → **GitHub issues created automatically** ✅ (FIXED)
- Runs weekly to catch external link rot
- Available on-demand via manual trigger

### Files Changed

- `.github/workflows/docs-validate.yml` - Removed error handling logic
- `.github/workflows/docs-preview.yml` - Removed `fail_on_error` parameter
- `.github/workflows/docs-deploy-latest.yml` - Removed `fail_on_error` parameter
- `.github/workflows/docs-deploy-version.yml` - Removed `fail_on_error` parameter
- `.github/workflows/docs-health-check.yml` - Removed `fail_on_error` parameter + push trigger

**Total:** -28 lines, +3 lines (net -25 lines of complexity)

## Checklist

* [x] I have performed a self-review of this change
* [x] Changes fix the reported bug (issue creation now works)
* [x] Changes optimize workflow triggers (no duplicate validation)

<details>
<summary>Is this a breaking change?</summary>
No - This fixes a bug and optimizes workflow triggers without breaking existing functionality.
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.