### PR TITLE
fix: modify config to ignore linting of kiro and changelog

### DIFF
--- a/.config/.markdownlint-cli2.jsonc
+++ b/.config/.markdownlint-cli2.jsonc
@@ -39,5 +39,7 @@
     ".git/**",
     "CHANGELOG.md",
     "THIRD-PARTY-LICENSES",
+    ".kiro/**",
+    ".chglog/**",
   ],
 }

--- a/.config/ci.markdownlint-cli2.jsonc
+++ b/.config/ci.markdownlint-cli2.jsonc
@@ -39,6 +39,8 @@
     ".git/**",
     "CHANGELOG.md",
     "THIRD-PARTY-LICENSES",
+    ".kiro/**",
+    ".chglog/**",
   ],
   "outputFormatters": [["markdownlint-cli2-formatter-sarif"]],
 }


### PR DESCRIPTION
**Issue number:**
N/A

## Summary

added kiro and changelog directories to the markdownlint config so they do not trigger warnings since these files are autogenerated.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
