### PR TITLE
fix(perforce/p4-server): fix admin password setup at security level 4

### DIFF
--- a/assets/packer/perforce/p4-server/p4_configure.sh
+++ b/assets/packer/perforce/p4-server/p4_configure.sh
@@ -776,8 +776,10 @@ EOF
 # Create the user
 cat /tmp/admin_user.txt | sudo -u perforce p4 -p "$P4PORT" -u super user -i -f
 
-# Set password
-echo "$ADMIN_PASSWORD" | sudo -u perforce p4 -p "$P4PORT" -u super passwd "$ADMIN_USERNAME"
+# Set admin user password
+# At security level 4, p4 passwd requires the password to be entered twice (new + confirm)
+# so we echo the password twice separated by newline
+echo -e "$ADMIN_PASSWORD\n$ADMIN_PASSWORD" | sudo -u perforce p4 -p "$P4PORT" -u super passwd "$ADMIN_USERNAME"
 
 # Grant super access
 sudo -u perforce p4 -p "$P4PORT" -u super protect -o | sudo -u perforce tee /tmp/protect.txt > /dev/null


### PR DESCRIPTION
## Summary
- Fixes admin user password setup failing silently during P4 server initialization
- At security level 4, `p4 passwd` requires password confirmation (enter twice)
- Previous implementation only echoed password once, causing setup to fail

## Test plan
- [ ] Deploy complete Perforce example with fresh infrastructure
- [ ] Verify admin user can log in with password from Secrets Manager
- [ ] Verify admin user can log in to Swarm