### PR TITLE
fix(perforce): add retry logic for helix-swarm install and fix a2enco…

### DIFF
--- a/assets/packer/perforce/p4-code-review/swarm_setup.sh
+++ b/assets/packer/perforce/p4-code-review/swarm_setup.sh
@@ -96,9 +96,18 @@ apt-get install -y apache2 \
 log_message "Installing PHP PECL extensions"
 apt-get install -y php${PHP_VERSION}-igbinary php${PHP_VERSION}-msgpack php${PHP_VERSION}-redis
 
-# Install Helix Swarm
+# Install Helix Swarm (retry up to 3 times to handle transient Perforce repo failures)
 log_message "Installing Helix Swarm"
-apt-get install -y helix-swarm
+for attempt in 1 2 3; do
+  apt-get install -y helix-swarm && break
+  log_message "helix-swarm install attempt ${attempt} failed, retrying in 30s..."
+  apt-get update
+  sleep 30
+  if [ $attempt -eq 3 ]; then
+    log_message "ERROR: helix-swarm install failed after 3 attempts"
+    exit 1
+  fi
+done
 
 # Install helix-swarm-optional package (LibreOffice, ImageMagick)
 if [ "${INSTALL_SWARM_OPTIONAL:-true}" = "true" ]; then
@@ -117,7 +126,7 @@ a2enmod setenvif
 
 # Enable PHP-FPM configuration for Apache
 log_message "Configuring PHP-FPM for Apache"
-a2enconf php*-fpm
+a2enconf php${PHP_VERSION}-fpm
 
 # Enable and configure Apache
 log_message "Enabling Apache service"


### PR DESCRIPTION
…nf glob

- Add retry loop (3 attempts, 30s delay) for helix-swarm apt install to handle transient Perforce repo failures during Packer AMI builds
- Replace a2enconf php*-fpm glob with explicit php${PHP_VERSION}-fpm to prevent exit code 2 when glob matches nothing or multiple configs

**Issue number:**

## Summary
Two fixes to assets/packer/perforce/p4-code-review/swarm_setup.sh to improve P4 Code Review Packer AMI build reliability:

Added retry logic (3 attempts, 30s delay, apt-get update between retries) for helix-swarm apt install to handle transient Perforce apt repo failures that caused intermittent build failures across accounts.
Changed a2enconf php*-fpm to a2enconf php${PHP_VERSION}-fpm — the glob could return exit code 2 if it matched nothing or multiple configs.

### Changes


Added retry logic (3 attempts, 30s delay, apt-get update between retries) for helix-swarm apt install to handle transient Perforce apt repo failures that caused intermittent build failures across accounts.
Changed a2enconf php*-fpm to a2enconf php${PHP_VERSION}-fpm — the glob could return exit code 2 if it matched nothing or multiple configs.


### User experience

Before: P4 Code Review Packer AMI build intermittently fails with exit code 2 during provisioning, requiring manual re-runs. Failures are inconsistent across accounts/regions.

After: Build automatically retries on transient repo failures and PHP-FPM config step is deterministic.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [ x] I have performed a self-review of this change
- [ x] Changes have been tested
- [ x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>
no 
</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
