### PR TITLE
Fix: Added metadata options to multiple Packer scripts for IMDSv2

### DIFF
--- a/assets/packer/build-agents/windows/windows.pkr.hcl
+++ b/assets/packer/build-agents/windows/windows.pkr.hcl
@@ -99,6 +99,14 @@ source "amazon-ebs" "base" {
   associate_public_ip_address = var.associate_public_ip_address
   ssh_interface = var.ssh_interface
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
+  }
+  imds_support = "v2.0"
+
   # storage specifications - expand root
   launch_block_device_mappings {
     device_name = "/dev/sda1"

--- a/assets/packer/perforce/p4-code-review/p4_code_review_x86.pkr.hcl
+++ b/assets/packer/perforce/p4-code-review/p4_code_review_x86.pkr.hcl
@@ -71,6 +71,14 @@ source "amazon-ebs" "ubuntu" {
   source_ami = data.amazon-ami.ubuntu.id
 
   ssh_username = "ubuntu"
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
+  }
+  imds_support = "v2.0"
 }
 
 build {

--- a/assets/packer/perforce/p4-server/perforce_arm64.pkr.hcl
+++ b/assets/packer/perforce/p4-server/perforce_arm64.pkr.hcl
@@ -60,6 +60,14 @@ source "amazon-ebs" "al2023" {
   }
 
   ssh_username = "ec2-user"
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
+  }
+  imds_support = "v2.0"
 }
 
 build {

--- a/assets/packer/perforce/p4-server/perforce_x86.pkr.hcl
+++ b/assets/packer/perforce/p4-server/perforce_x86.pkr.hcl
@@ -60,6 +60,14 @@ source "amazon-ebs" "al2023" {
   }
 
   ssh_username = "ec2-user"
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
+  }
+  imds_support = "v2.0"
 }
 
 build {

--- a/assets/packer/virtual-workstations/lightweight/windows-server-2025-lightweight.pkr.hcl
+++ b/assets/packer/virtual-workstations/lightweight/windows-server-2025-lightweight.pkr.hcl
@@ -107,6 +107,14 @@ source "amazon-ebs" "lightweight" {
   associate_public_ip_address     = var.associate_public_ip_address
   capacity_reservation_preference = var.capacity_reservation_preference
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
+  }
+  imds_support = "v2.0"
+
   launch_block_device_mappings {
     device_name           = "/dev/sda1"
     volume_size           = var.root_volume_size

--- a/assets/packer/virtual-workstations/ue-gamedev/windows-server-2025-ue-gamedev.pkr.hcl
+++ b/assets/packer/virtual-workstations/ue-gamedev/windows-server-2025-ue-gamedev.pkr.hcl
@@ -107,6 +107,14 @@ source "amazon-ebs" "ue-gamedev" {
   associate_public_ip_address     = var.associate_public_ip_address
   capacity_reservation_preference = var.capacity_reservation_preference
 
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+    instance_metadata_tags      = "enabled"
+  }
+  imds_support = "v2.0"
+
   launch_block_device_mappings {
     device_name           = "/dev/sda1"
     volume_size           = var.root_volume_size


### PR DESCRIPTION
Fixes 

**Issue number: #918 **

## Summary
Adds Metadata options blocks and http options to multiple Packer scripts to comply with AWS internal IMDSv2 enforcement

### Changes

> Please provide a summary of what's being changed
Added metadata options blocks to 6 Packer scripts, and added options to force IMDSv2.

Example:
`metadata_options {
http_endpoint = "enabled"
http_tokens = "required"
http_put_response_hop_limit = 1
}`

### User experience

> Please share what the user experience looks like before and after this change

For AWS internal accounts, Packer scripts would fail with a status code 400 as theyre using IMDSv1.
After this change, IMDSv2 is enforced, so Packer scripts run successfully.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
