### PR TITLE
fix: update base_infrastructure.ps1 to use IMDSv2

### DIFF
--- a/assets/packer/virtual-workstations/shared/base_infrastructure.ps1
+++ b/assets/packer/virtual-workstations/shared/base_infrastructure.ps1
@@ -8,7 +8,9 @@ Write-Host "Starting shared VDI base infrastructure setup..."
 New-Item -ItemType Directory -Force -Path "C:\temp" | Out-Null
 
 # Install NVIDIA GRID drivers if GPU instance
-$instanceType = (Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-type" -TimeoutSec 10)
+# IMDSv2: fetch a session token first, then use it for metadata requests
+$imdsToken = (Invoke-RestMethod -Method PUT -Uri "http://169.254.169.254/latest/api/token" -Headers @{"X-aws-ec2-metadata-token-ttl-seconds" = "300"} -TimeoutSec 10)
+$instanceType = (Invoke-RestMethod -Uri "http://169.254.169.254/latest/meta-data/instance-type" -Headers @{"X-aws-ec2-metadata-token" = $imdsToken} -TimeoutSec 10)
 if ($instanceType -match "^(g3|g4|g5|g6|p2|p3|p4)") {
     Write-Host "GPU instance detected ($instanceType), installing NVIDIA GRID drivers..."
 


### PR DESCRIPTION


**Issue number:#921**

## Summary
Windows Packer AMIs fail to build, related to line 11 of base_infrastructure.ps1, which is making a plain IMDSv1 call without token header.

### Changes

> Please provide a summary of what's being changed
Adding a token fetch to base_infrastructure.ps1 before it calls the metadata endpoint

### User experience

> Please share what the user experience looks like before and after this change
Before: No AMI
After: Yes AMI

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
