### PR TITLE
feat(unreal): add Lore VCS module

### DIFF
--- a/modules/unreal/lore/.terraform-docs.yml
+++ b/modules/unreal/lore/.terraform-docs.yml
@@ -1,0 +1,20 @@
+formatter: "markdown table"
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: required
+
+settings:
+  escape: true
+  type: true
+  required: true
+  default: true
+  description: true

--- a/modules/unreal/lore/.tflint.hcl
+++ b/modules/unreal/lore/.tflint.hcl
@@ -1,0 +1,36 @@
+tflint {
+  required_version = ">= 0.50"
+}
+
+config {
+  call_module_type    = "local"
+  disabled_by_default = false
+}
+
+plugin "terraform" {
+  enabled = true
+  version = "0.10.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-terraform"
+  preset  = "recommended"
+}
+
+plugin "aws" {
+  enabled = true
+  version = "0.38.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}
+
+# Terraform language rules
+rule "terraform_naming_convention" { enabled = true }
+rule "terraform_documented_variables" { enabled = true }
+rule "terraform_documented_outputs" { enabled = true }
+rule "terraform_unused_declarations" { enabled = true }
+rule "terraform_standard_module_structure" { enabled = true }
+
+# AWS best practice rules (opt-in)
+# Disabled: fires false positives on module composition (sub-modules propagate
+# tags via var.tags, but tflint can't trace variable->resource tag inheritance)
+# rule "aws_resource_missing_tags" {
+#   enabled = true
+#   tags    = ["Project", "Environment"]
+# }

--- a/modules/unreal/lore/README.md
+++ b/modules/unreal/lore/README.md
@@ -1,0 +1,41 @@
+# Lore on AWS
+
+Terraform module for deploying Lore — version control for large binary game assets — on AWS.
+
+## What This Module Creates
+
+- **Edge pods** — NVMe-cached nodes that clients connect to for push and clone
+- **Durable backend** — S3 for fragments, DynamoDB for metadata (managed by the module)
+- **Observability** — CloudWatch logs, optional X-Ray tracing
+
+You provide: a container image and a list of allowed client CIDRs.
+
+## Quick Start
+
+```bash
+cd examples/default
+terraform init && terraform apply
+```
+
+Connect:
+
+```bash
+lore clone lores://<edge_pod_ip>:41337/my-repo
+```
+
+## Examples
+
+| Example | What it adds |
+|---------|--------------|
+| [default](examples/default/) | 2 edge pods + durable backend |
+| [cognito](examples/cognito/) | + Cognito auth, X-Ray tracing, deletion protection |
+| [external-auth](examples/external-auth/) | + External IdP (Okta, Azure AD, etc.) |
+| [minimal](examples/minimal/) | Backend only, no edge pods (dev/test) |
+
+## Documentation
+
+For full Lore documentation including getting started guides, scaling, authentication modes, and security, visit [lore.org](https://lore.org).
+
+## Need Help?
+
+Open an issue with your Terraform version, error output, and what you've already tried.

--- a/modules/unreal/lore/examples/cognito/README.md
+++ b/modules/unreal/lore/examples/cognito/README.md
@@ -1,0 +1,39 @@
+# Cognito Auth Example
+
+Default topology (write tier + 2 edge pods) with Cognito authentication and X-Ray observability.
+
+## What it adds over default
+
+- Cognito User Pool with app client (client_credentials grant)
+- ADOT sidecar for X-Ray tracing
+- Deletion protection on DynamoDB tables
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit with your container image and CIDR
+
+terraform init
+terraform apply
+```
+
+## Connect
+
+Obtain a token, then clone:
+
+```bash
+TOKEN=$(curl -s -X POST "<cognito_token_endpoint>" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials&client_id=<client_id>&client_secret=<client_secret>" \
+  | jq -r '.access_token')
+
+lore clone --token "$TOKEN" lores://<edge_1_ip>:41337/my-repo
+```
+
+## Tear down
+
+```bash
+terraform destroy
+# Takes ~6 minutes
+```

--- a/modules/unreal/lore/examples/cognito/main.tf
+++ b/modules/unreal/lore/examples/cognito/main.tf
@@ -1,0 +1,60 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+# This example extends the default topology (write tier + edge pods) with:
+# - Cognito authentication (client_credentials grant)
+# - X-Ray tracing via ADOT sidecar
+# - Deletion protection enabled (production-safe)
+#
+# Start with examples/default/ if you don't need auth yet.
+
+# =============================================================================
+# Write Tier
+# =============================================================================
+
+module "lore" {
+  source = "../../"
+
+  project_prefix        = "lore"
+  environment           = "prod"
+  container_image       = var.container_image
+  allowed_ingress_cidrs = var.allowed_ingress_cidrs
+  instance_type         = "c8gd.8xlarge"
+
+  auth_mode           = "cognito"
+  enable_otel_sidecar = true
+
+  enable_deletion_protection = var.enable_deletion_protection
+  enable_force_destroy       = var.enable_force_destroy
+}
+
+# =============================================================================
+# Edge Pods
+# =============================================================================
+
+module "edge_1" {
+  source = "../../modules/edge-pod"
+
+  vpc_id                   = module.lore.vpc_id
+  subnet_id                = module.lore.private_subnet_ids[0]
+  server_security_group_id = module.lore.server_security_group_id
+  container_image          = var.container_image
+  write_tier_dns           = module.lore.write_tier_discovery_dns
+  ca_certificate_pem       = module.lore.ca_certificate_pem
+  allowed_ingress_cidrs    = var.allowed_ingress_cidrs
+  name_prefix              = "edge-1"
+}
+
+module "edge_2" {
+  source = "../../modules/edge-pod"
+
+  vpc_id                   = module.lore.vpc_id
+  subnet_id                = module.lore.private_subnet_ids[1]
+  server_security_group_id = module.lore.server_security_group_id
+  container_image          = var.container_image
+  write_tier_dns           = module.lore.write_tier_discovery_dns
+  ca_certificate_pem       = module.lore.ca_certificate_pem
+  allowed_ingress_cidrs    = var.allowed_ingress_cidrs
+  name_prefix              = "edge-2"
+}

--- a/modules/unreal/lore/examples/cognito/outputs.tf
+++ b/modules/unreal/lore/examples/cognito/outputs.tf
@@ -1,0 +1,29 @@
+output "write_tier_dns" {
+  value = module.lore.write_tier_discovery_dns
+}
+
+output "edge_1_ip" {
+  value = module.edge_1.private_ip
+}
+
+output "edge_2_ip" {
+  value = module.edge_2.private_ip
+}
+
+output "ca_certificate_pem" {
+  value     = module.lore.ca_certificate_pem
+  sensitive = true
+}
+
+output "cognito_token_endpoint" {
+  value = module.lore.cognito_token_endpoint
+}
+
+output "cognito_client_id" {
+  value = module.lore.cognito_client_id
+}
+
+output "cognito_client_secret" {
+  value     = module.lore.cognito_client_secret
+  sensitive = true
+}

--- a/modules/unreal/lore/examples/cognito/terraform.tfvars.example
+++ b/modules/unreal/lore/examples/cognito/terraform.tfvars.example
@@ -1,0 +1,4 @@
+# Copy this file to terraform.tfvars and fill in your values.
+
+container_image       = "123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:v1.0.0"
+allowed_ingress_cidrs = ["203.0.113.0/24"]  # Your studio office/VPN CIDR

--- a/modules/unreal/lore/examples/cognito/variables.tf
+++ b/modules/unreal/lore/examples/cognito/variables.tf
@@ -1,0 +1,26 @@
+variable "container_image" {
+  description = "Loreserver container image URI (e.g., 123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:v1.0.0)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}\\.dkr\\.ecr\\.", var.container_image))
+    error_message = "Must be an ECR image URI. Format: <account_id>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>"
+  }
+}
+
+variable "allowed_ingress_cidrs" {
+  description = "CIDR blocks allowed to reach Lore (e.g., your studio office CIDR)"
+  type        = list(string)
+}
+
+variable "enable_deletion_protection" {
+  description = "Enable deletion protection on DynamoDB tables"
+  type        = bool
+  default     = true
+}
+
+variable "enable_force_destroy" {
+  description = "Allow S3 bucket deletion even when non-empty"
+  type        = bool
+  default     = false
+}

--- a/modules/unreal/lore/examples/cognito/versions.tf
+++ b/modules/unreal/lore/examples/cognito/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}

--- a/modules/unreal/lore/examples/default/README.md
+++ b/modules/unreal/lore/examples/default/README.md
@@ -1,0 +1,33 @@
+# Default Example
+
+Write tier + 2 edge pods with Cloud Map service discovery. No auth.
+
+## What it creates
+
+- Write tier: ECS on c8gd.8xlarge with S3+DynamoDB storage, Cloud Map registration
+- Edge pod 1: EC2 with NVMe cache in AZ-a
+- Edge pod 2: EC2 with NVMe cache in AZ-b
+- Cloud Map private DNS for edge pod → write tier discovery
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit with your container image and CIDR
+
+terraform init
+terraform apply
+```
+
+## Connect
+
+```bash
+lore clone lores://<edge_1_ip>:41337/my-repo
+```
+
+## Tear down
+
+```bash
+terraform destroy
+# Takes ~12 minutes (capacity provider reconciliation)
+```

--- a/modules/unreal/lore/examples/default/main.tf
+++ b/modules/unreal/lore/examples/default/main.tf
@@ -1,0 +1,65 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+# =============================================================================
+# Write Tier
+# =============================================================================
+
+module "lore" {
+  source = "../../"
+
+  project_prefix        = "lore"
+  environment           = "dev"
+  container_image       = var.container_image
+  allowed_ingress_cidrs = var.allowed_ingress_cidrs
+  instance_type         = "c8gd.8xlarge"
+
+  enable_deletion_protection = false
+  enable_force_destroy       = true
+  asg_desired_size           = 1
+  auth_mode                  = "none"
+}
+
+# =============================================================================
+# Edge Pods
+# =============================================================================
+
+module "edge_1" {
+  source = "../../modules/edge-pod"
+
+  # Where to place this edge pod (can be any VPC with connectivity to write tier)
+  vpc_id    = module.lore.vpc_id
+  subnet_id = module.lore.private_subnet_ids[0]
+
+  # Allow edge pod to reach the write tier's network
+  server_security_group_id = module.lore.server_security_group_id
+
+  # Same container image as the write tier
+  container_image = var.container_image
+
+  # Write tier Cloud Map DNS (gRPC:41337 + QUIC replication:41340)
+  write_tier_dns = module.lore.write_tier_discovery_dns
+
+  # Trust the write tier's TLS certificate
+  ca_certificate_pem = module.lore.ca_certificate_pem
+
+  # Who can connect to this edge pod
+  allowed_ingress_cidrs = var.allowed_ingress_cidrs
+  name_prefix           = "edge-1"
+  tags                  = { Role = "edge-pod", Index = "1" }
+}
+
+module "edge_2" {
+  source = "../../modules/edge-pod"
+
+  vpc_id                   = module.lore.vpc_id
+  subnet_id                = module.lore.private_subnet_ids[1]
+  server_security_group_id = module.lore.server_security_group_id
+  container_image          = var.container_image
+  write_tier_dns           = module.lore.write_tier_discovery_dns
+  ca_certificate_pem       = module.lore.ca_certificate_pem
+  allowed_ingress_cidrs    = var.allowed_ingress_cidrs
+  name_prefix              = "edge-2"
+  tags                     = { Role = "edge-pod", Index = "2" }
+}

--- a/modules/unreal/lore/examples/default/outputs.tf
+++ b/modules/unreal/lore/examples/default/outputs.tf
@@ -1,0 +1,16 @@
+output "write_tier_dns" {
+  value = module.lore.write_tier_discovery_dns
+}
+
+output "edge_1_ip" {
+  value = module.edge_1.private_ip
+}
+
+output "edge_2_ip" {
+  value = module.edge_2.private_ip
+}
+
+output "ca_certificate_pem" {
+  value     = module.lore.ca_certificate_pem
+  sensitive = true
+}

--- a/modules/unreal/lore/examples/default/terraform.tfvars.example
+++ b/modules/unreal/lore/examples/default/terraform.tfvars.example
@@ -1,0 +1,2 @@
+container_image       = "123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:arm64"
+allowed_ingress_cidrs = ["10.0.0.0/8"]

--- a/modules/unreal/lore/examples/default/variables.tf
+++ b/modules/unreal/lore/examples/default/variables.tf
@@ -1,0 +1,14 @@
+variable "container_image" {
+  description = "Loreserver container image URI (e.g., 123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:arm64)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}\\.dkr\\.ecr\\.", var.container_image))
+    error_message = "Must be an ECR image URI. Format: <account_id>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>"
+  }
+}
+
+variable "allowed_ingress_cidrs" {
+  description = "CIDR blocks allowed to reach Lore write tier and edge pods"
+  type        = list(string)
+}

--- a/modules/unreal/lore/examples/default/versions.tf
+++ b/modules/unreal/lore/examples/default/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/unreal/lore/examples/external-auth/README.md
+++ b/modules/unreal/lore/examples/external-auth/README.md
@@ -1,0 +1,33 @@
+# External Auth Example
+
+Default topology (write tier + 2 edge pods) with an external IdP (Okta, Azure AD, etc.).
+
+## What it adds over default
+
+- JWT validation against your IdP's JWKS endpoint
+- Requires `auth_jwk_endpoint`, `auth_jwt_issuer`, `auth_jwt_audience` variables
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit with your container image, CIDR, and IdP details
+
+terraform init
+terraform apply
+```
+
+## Connect
+
+Obtain a token from your IdP, then clone:
+
+```bash
+lore clone --token "$TOKEN" lores://<edge_1_ip>:41337/my-repo
+```
+
+## Tear down
+
+```bash
+terraform destroy
+# Takes ~6 minutes
+```

--- a/modules/unreal/lore/examples/external-auth/main.tf
+++ b/modules/unreal/lore/examples/external-auth/main.tf
@@ -1,0 +1,54 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+# =============================================================================
+# Write Tier
+# =============================================================================
+
+module "lore" {
+  source = "../../"
+
+  project_prefix        = "lore"
+  environment           = "prod"
+  container_image       = var.container_image
+  allowed_ingress_cidrs = var.allowed_ingress_cidrs
+  instance_type         = "c8gd.8xlarge"
+
+  enable_otel_sidecar = true
+
+  auth_mode         = "external"
+  auth_jwk_endpoint = var.auth_jwk_endpoint
+  auth_jwt_issuer   = var.auth_jwt_issuer
+  auth_jwt_audience = var.auth_jwt_audience
+}
+
+# =============================================================================
+# Edge Pods
+# =============================================================================
+
+module "edge_1" {
+  source = "../../modules/edge-pod"
+
+  vpc_id                   = module.lore.vpc_id
+  subnet_id                = module.lore.private_subnet_ids[0]
+  server_security_group_id = module.lore.server_security_group_id
+  container_image          = var.container_image
+  write_tier_dns           = module.lore.write_tier_discovery_dns
+  ca_certificate_pem       = module.lore.ca_certificate_pem
+  allowed_ingress_cidrs    = var.allowed_ingress_cidrs
+  name_prefix              = "edge-1"
+}
+
+module "edge_2" {
+  source = "../../modules/edge-pod"
+
+  vpc_id                   = module.lore.vpc_id
+  subnet_id                = module.lore.private_subnet_ids[1]
+  server_security_group_id = module.lore.server_security_group_id
+  container_image          = var.container_image
+  write_tier_dns           = module.lore.write_tier_discovery_dns
+  ca_certificate_pem       = module.lore.ca_certificate_pem
+  allowed_ingress_cidrs    = var.allowed_ingress_cidrs
+  name_prefix              = "edge-2"
+}

--- a/modules/unreal/lore/examples/external-auth/outputs.tf
+++ b/modules/unreal/lore/examples/external-auth/outputs.tf
@@ -1,0 +1,16 @@
+output "write_tier_dns" {
+  value = module.lore.write_tier_discovery_dns
+}
+
+output "edge_1_ip" {
+  value = module.edge_1.private_ip
+}
+
+output "edge_2_ip" {
+  value = module.edge_2.private_ip
+}
+
+output "ca_certificate_pem" {
+  value     = module.lore.ca_certificate_pem
+  sensitive = true
+}

--- a/modules/unreal/lore/examples/external-auth/terraform.tfvars.example
+++ b/modules/unreal/lore/examples/external-auth/terraform.tfvars.example
@@ -1,0 +1,9 @@
+# Copy this file to terraform.tfvars and fill in your values.
+
+container_image       = "123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:v1.0.0"
+allowed_ingress_cidrs = ["203.0.113.0/24"]
+
+# Your identity provider's endpoints
+auth_jwk_endpoint = "https://login.yourstudio.com/.well-known/jwks.json"
+auth_jwt_issuer   = "https://login.yourstudio.com"
+auth_jwt_audience = ["lore-server"]

--- a/modules/unreal/lore/examples/external-auth/variables.tf
+++ b/modules/unreal/lore/examples/external-auth/variables.tf
@@ -1,0 +1,30 @@
+variable "container_image" {
+  description = "Loreserver container image URI"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}\\.dkr\\.ecr\\.", var.container_image))
+    error_message = "Must be an ECR image URI. Format: <account_id>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>"
+  }
+}
+
+variable "allowed_ingress_cidrs" {
+  description = "CIDR blocks allowed to reach Lore"
+  type        = list(string)
+}
+
+variable "auth_jwk_endpoint" {
+  description = "Your IdP's JWKS endpoint URL (e.g., https://login.yourstudio.com/.well-known/jwks.json)"
+  type        = string
+}
+
+variable "auth_jwt_issuer" {
+  description = "JWT issuer string from your IdP (e.g., https://login.yourstudio.com)"
+  type        = string
+}
+
+variable "auth_jwt_audience" {
+  description = "JWT audience values the server should accept"
+  type        = list(string)
+  default     = ["lore-server"]
+}

--- a/modules/unreal/lore/examples/external-auth/versions.tf
+++ b/modules/unreal/lore/examples/external-auth/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}

--- a/modules/unreal/lore/examples/minimal/README.md
+++ b/modules/unreal/lore/examples/minimal/README.md
@@ -1,0 +1,33 @@
+# Minimal Example
+
+Write tier only — no edge pods. For development and testing where you don't need horizontal scaling.
+
+For production deployments, use the [default](../default/) example.
+
+## What it creates
+
+- Single ECS task on i4i.xlarge (NVMe-backed)
+- No auth, no edge pods, no observability
+- Deletion protection disabled, force destroy enabled
+
+## Usage
+
+```bash
+cp terraform.tfvars.example terraform.tfvars
+# Edit with your container image and CIDR
+
+terraform init
+terraform apply
+```
+
+## Connect
+
+Clients connect via Cloud Map DNS (requires VPN/DirectConnect to the VPC):
+
+```bash
+lore clone lores://<write_tier_dns>:41337/my-repo
+```
+
+## Cost
+
+~$2/month when idle (S3 storage only). Instance cost only while running.

--- a/modules/unreal/lore/examples/minimal/main.tf
+++ b/modules/unreal/lore/examples/minimal/main.tf
@@ -1,0 +1,19 @@
+provider "aws" {
+  region = "us-west-2"
+}
+
+module "lore" {
+  source = "../../"
+
+  environment           = "dev"
+  container_image       = var.container_image
+  allowed_ingress_cidrs = var.allowed_ingress_cidrs
+
+  # Dev-friendly: cheap instance, no NVMe requirement, no protection
+  instance_type              = "i4i.xlarge"
+  enable_deletion_protection = false
+  enable_force_destroy       = true
+  asg_desired_size           = 1
+  auth_mode                  = "none"
+}
+

--- a/modules/unreal/lore/examples/minimal/outputs.tf
+++ b/modules/unreal/lore/examples/minimal/outputs.tf
@@ -1,0 +1,15 @@
+output "write_tier_dns" {
+  description = "Cloud Map DNS for the write tier (connect via VPN/DirectConnect to private subnet)"
+  value       = module.lore.write_tier_discovery_dns
+}
+
+output "ca_certificate_pem" {
+  description = "CA cert for client trust bundle"
+  value       = module.lore.ca_certificate_pem
+  sensitive   = true
+}
+
+output "vpc_id" {
+  description = "VPC ID (for adding edge pods later)"
+  value       = module.lore.vpc_id
+}

--- a/modules/unreal/lore/examples/minimal/terraform.tfvars.example
+++ b/modules/unreal/lore/examples/minimal/terraform.tfvars.example
@@ -1,0 +1,7 @@
+# Copy this file to terraform.tfvars and fill in your values.
+#
+# container_image: Your Lore server ECR image URI
+# allowed_ingress_cidrs: Network ranges that can reach the server
+
+container_image       = "123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:v0.1.0"
+allowed_ingress_cidrs = ["10.0.0.0/8"]

--- a/modules/unreal/lore/examples/minimal/variables.tf
+++ b/modules/unreal/lore/examples/minimal/variables.tf
@@ -1,0 +1,14 @@
+variable "container_image" {
+  description = "Loreserver container image URI (e.g., 123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:v0.1.0)"
+  type        = string
+
+  validation {
+    condition     = can(regex("^[0-9]{12}\\.dkr\\.ecr\\.", var.container_image))
+    error_message = "Must be an ECR image URI. Format: <account_id>.dkr.ecr.<region>.amazonaws.com/<repo>:<tag>"
+  }
+}
+
+variable "allowed_ingress_cidrs" {
+  description = "CIDR blocks allowed to reach Lore (e.g., [\"10.0.0.0/8\"] for internal, or your office IP)"
+  type        = list(string)
+}

--- a/modules/unreal/lore/examples/minimal/versions.tf
+++ b/modules/unreal/lore/examples/minimal/versions.tf
@@ -1,0 +1,6 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+  }
+}

--- a/modules/unreal/lore/locals.tf
+++ b/modules/unreal/lore/locals.tf
@@ -1,0 +1,50 @@
+locals {
+  name_prefix = "${var.project_prefix}-${var.environment}"
+
+  tags = {
+    Project     = var.project_prefix
+    Environment = var.environment
+    ManagedBy   = "terraform"
+  }
+
+  # Decision 7: Validate instance store requirement
+  validate_instance_store = (
+    !var.require_instance_store ||
+    can(regex("^(i4i|i3en|im4gn|is4gen|c8gd|c7gd|m7gd|r7gd|r6id)", var.instance_type))
+  )
+}
+
+# Cross-variable validation (Terraform can't do this in variable blocks)
+check "instance_store_validation" {
+  assert {
+    condition     = local.validate_instance_store
+    error_message = "When require_instance_store is true, instance_type must be from an instance store family (i4i, i3en, im4gn, is4gen, c8gd, c7gd, m7gd, r7gd, r6id). Set require_instance_store = false to override."
+  }
+}
+
+check "ingress_cidr_not_open" {
+  assert {
+    condition     = !contains(var.allowed_ingress_cidrs, "0.0.0.0/0")
+    error_message = "It is recommended to use specific CIDRs for your studio network rather than 0.0.0.0/0. See docs/user/security.md for guidance."
+  }
+}
+
+check "tiering_days_ordering" {
+  assert {
+    condition = (
+      var.intelligent_tiering_archive_days == 0 ||
+      var.intelligent_tiering_deep_archive_days > var.intelligent_tiering_archive_days
+    )
+    error_message = "intelligent_tiering_deep_archive_days must be greater than intelligent_tiering_archive_days when tiering is enabled."
+  }
+}
+
+check "arm64_instance_needs_arm64_image" {
+  assert {
+    condition = (
+      !contains(["c8gd", "c8g", "c7gd", "c7g", "c7gn", "m7g", "m7gd", "m8g", "r7g", "r7gd", "r8g", "t4g", "im4gn", "is4gen", "x2gd", "hpc7g"], split(".", var.instance_type)[0]) ||
+      can(regex("arm64|aarch64|graviton", lower(var.container_image)))
+    )
+    error_message = "ARM64/Graviton instance types (c8gd, c7g, m7g, t4g, etc.) require an ARM64 container image. Verify your image supports linux/arm64."
+  }
+}

--- a/modules/unreal/lore/main.tf
+++ b/modules/unreal/lore/main.tf
@@ -1,0 +1,255 @@
+# =============================================================================
+# Availability Zones — dynamic lookup when not explicitly provided
+# =============================================================================
+
+data "aws_availability_zones" "available" {
+  state = "available"
+}
+
+locals {
+  availability_zones = var.availability_zones != null ? var.availability_zones : (
+    length(data.aws_availability_zones.available.names) >= 2
+    ? slice(data.aws_availability_zones.available.names, 0, 2)
+    : []
+  )
+}
+
+# =============================================================================
+# VPC — create or use existing (Decision 12)
+# =============================================================================
+
+module "vpc" {
+  count  = var.vpc_id == null ? 1 : 0
+  source = "./modules/vpc"
+
+  vpc_cidr           = var.vpc_cidr
+  name_prefix        = local.name_prefix
+  availability_zones = local.availability_zones
+  tags               = local.tags
+  enable_flow_logs   = var.enable_vpc_flow_logs
+}
+
+locals {
+  vpc_id             = var.vpc_id != null ? var.vpc_id : module.vpc[0].vpc_id
+  private_subnet_ids = var.private_subnet_ids != null ? var.private_subnet_ids : module.vpc[0].private_subnet_ids
+  public_subnet_ids  = var.public_subnet_ids != null ? var.public_subnet_ids : module.vpc[0].public_subnet_ids
+}
+
+# =============================================================================
+# Data Layer — S3 + DynamoDB (Phase 1A)
+# =============================================================================
+
+module "data" {
+  source = "./modules/storage"
+
+  name_prefix                           = local.name_prefix
+  tags                                  = local.tags
+  enable_force_destroy                  = var.enable_force_destroy
+  enable_deletion_protection            = var.enable_deletion_protection
+  intelligent_tiering_archive_days      = var.intelligent_tiering_archive_days
+  intelligent_tiering_deep_archive_days = var.intelligent_tiering_deep_archive_days
+}
+
+# =============================================================================
+# Networking — Security Groups + VPC Endpoints
+# =============================================================================
+
+resource "aws_security_group" "server" {
+  name_prefix = "${local.name_prefix}-server-"
+  vpc_id      = local.vpc_id
+  description = "Lore server access"
+
+  tags = merge(local.tags, { Name = "${local.name_prefix}-server-sg" })
+
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "quic" {
+  for_each          = toset(var.allowed_ingress_cidrs)
+  security_group_id = aws_security_group.server.id
+  from_port         = 41337
+  to_port           = 41337
+  ip_protocol       = "udp"
+  cidr_ipv4         = each.value
+  description       = "QUIC bulk transfer from ${each.value}"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "grpc" {
+  for_each          = toset(var.allowed_ingress_cidrs)
+  security_group_id = aws_security_group.server.id
+  from_port         = 41337
+  to_port           = 41337
+  ip_protocol       = "tcp"
+  cidr_ipv4         = each.value
+  description       = "gRPC RPCs from ${each.value}"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "http" {
+  for_each          = toset(var.allowed_ingress_cidrs)
+  security_group_id = aws_security_group.server.id
+  from_port         = 41339
+  to_port           = 41339
+  ip_protocol       = "tcp"
+  cidr_ipv4         = each.value
+  description       = "HTTP health checks and presigned URLs from ${each.value}"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "replication" {
+  security_group_id            = aws_security_group.server.id
+  from_port                    = 41340
+  to_port                      = 41340
+  ip_protocol                  = "tcp"
+  referenced_security_group_id = aws_security_group.server.id
+  description                  = "Replication gRPC from peer Lore servers"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "replication_quic" {
+  security_group_id            = aws_security_group.server.id
+  from_port                    = 41340
+  to_port                      = 41340
+  ip_protocol                  = "udp"
+  referenced_security_group_id = aws_security_group.server.id
+  description                  = "Replication QUIC from peer Lore servers"
+}
+
+resource "aws_vpc_security_group_egress_rule" "https" {
+  security_group_id = aws_security_group.server.id
+  from_port         = 443
+  to_port           = 443
+  ip_protocol       = "tcp"
+  cidr_ipv4         = "0.0.0.0/0"
+  description       = "HTTPS to AWS services via NAT"
+}
+
+resource "aws_vpc_security_group_egress_rule" "replication_egress" {
+  security_group_id            = aws_security_group.server.id
+  ip_protocol                  = "-1"
+  referenced_security_group_id = aws_security_group.server.id
+  description                  = "All traffic to peer Lore servers"
+}
+
+data "aws_region" "current" {}
+
+resource "aws_vpc_endpoint" "s3" {
+  count             = var.vpc_id == null ? 1 : 0
+  vpc_id            = local.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [module.vpc[0].private_route_table_id]
+
+  tags = merge(local.tags, { Name = "${local.name_prefix}-s3-endpoint" })
+}
+
+resource "aws_vpc_endpoint" "dynamodb" {
+  count             = var.vpc_id == null ? 1 : 0
+  vpc_id            = local.vpc_id
+  service_name      = "com.amazonaws.${data.aws_region.current.name}.dynamodb"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = [module.vpc[0].private_route_table_id]
+
+  tags = merge(local.tags, { Name = "${local.name_prefix}-dynamodb-endpoint" })
+}
+
+# =============================================================================
+# Auth — Cognito (conditional on auth_mode == "cognito")
+# =============================================================================
+
+module "auth" {
+  count  = var.auth_mode == "cognito" ? 1 : 0
+  source = "./modules/auth"
+
+  name_prefix = local.name_prefix
+  environment = var.environment
+  tags        = local.tags
+}
+
+# =============================================================================
+# Compute — ECS Cluster, ASG, Task Definition, Service, IAM
+# =============================================================================
+
+module "compute" {
+  source = "./modules/compute"
+
+  name_prefix         = local.name_prefix
+  tags                = local.tags
+  environment         = var.environment
+  fragment_bucket_arn = module.data.fragment_bucket_arn
+  dynamodb_table_arns = [
+    module.data.fragments_table_arn,
+    module.data.fragment_metadata_table_arn,
+    module.data.mutable_store_table_arn,
+    module.data.locks_table_arn,
+  ]
+  locks_table_arn              = module.data.locks_table_arn
+  private_subnet_ids           = local.private_subnet_ids
+  server_security_group_id     = aws_security_group.server.id
+  instance_type                = var.instance_type
+  container_memory_reservation = var.container_memory_reservation
+  cache_max_size_bytes         = var.cache_max_size_bytes
+  ami_id                       = var.ami_id
+  container_user               = var.container_user
+  asg_min_size                 = var.asg_min_size
+  asg_max_size                 = var.asg_max_size
+  asg_desired_size             = var.asg_desired_size
+
+  # Phase 5B: ECS service
+  container_image              = var.container_image
+  fragment_bucket_name         = module.data.fragment_bucket_name
+  fragments_table_name         = module.data.fragments_table_name
+  fragment_metadata_table_name = module.data.fragment_metadata_table_name
+  mutable_store_table_name     = module.data.mutable_store_table_name
+  locks_table_name             = module.data.locks_table_name
+
+  # Phase 6: Security & Observability
+  tls_certificate_secret_arn         = var.tls_certificate_secret_arn
+  tls_private_key_secret_arn         = var.tls_private_key_secret_arn
+  tls_san_dns_names                  = var.tls_san_dns_names
+  hmac_key_secret_arn                = var.hmac_key_secret_arn
+  write_tier_dns_name                = "write-tier.${local.name_prefix}.internal"
+  enable_otel_sidecar                = var.enable_otel_sidecar
+  otel_collector_image               = var.otel_collector_image
+  auth_mode                          = var.auth_mode
+  auth_jwk_endpoint                  = var.auth_mode == "cognito" ? module.auth[0].jwk_endpoint : var.auth_jwk_endpoint
+  auth_jwt_issuer                    = var.auth_mode == "cognito" ? module.auth[0].issuer : var.auth_jwt_issuer
+  auth_jwt_audience                  = var.auth_jwt_audience
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = var.deployment_maximum_percent
+  log_retention_days                 = var.log_retention_days
+  enable_xray_smoke_test             = var.enable_xray_smoke_test
+  enable_replication                 = true
+  service_discovery_registry_arn     = aws_service_discovery_service.write_tier.arn
+}
+
+# =============================================================================
+# Service Discovery — Cloud Map (edge pod → write tier DNS)
+# =============================================================================
+
+resource "aws_service_discovery_private_dns_namespace" "lore" {
+  name        = "${local.name_prefix}.internal"
+  description = "Lore write tier service discovery for edge pods"
+  vpc         = local.vpc_id
+  tags        = local.tags
+}
+
+resource "aws_service_discovery_service" "write_tier" {
+  name = "write-tier"
+
+  dns_config {
+    namespace_id = aws_service_discovery_private_dns_namespace.lore.id
+
+    dns_records {
+      type = "A"
+      ttl  = 10
+    }
+
+    routing_policy = "MULTIVALUE"
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+
+  tags = local.tags
+}
+
+

--- a/modules/unreal/lore/modules/auth/README.md
+++ b/modules/unreal/lore/modules/auth/README.md
@@ -1,0 +1,59 @@
+# Auth Module
+
+Cognito user pool with M2M client credentials grant for Lore server authentication.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cognito_resource_server.lore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_resource_server) | resource |
+| [aws_cognito_user_pool.lore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool) | resource |
+| [aws_cognito_user_pool_client.lore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_client) | resource |
+| [aws_cognito_user_pool_domain.lore](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cognito_user_pool_domain) | resource |
+| [aws_iam_role.pre_token_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.pre_token_lambda_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_lambda_function.pre_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.cognito_invoke](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [archive_file.pre_token](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_iam_policy_document.lambda_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (used in Cognito domain) | `string` | n/a | yes |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all resource names | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_client_id"></a> [client\_id](#output\_client\_id) | Cognito app client ID |
+| <a name="output_client_secret"></a> [client\_secret](#output\_client\_secret) | Cognito app client secret |
+| <a name="output_issuer"></a> [issuer](#output\_issuer) | JWT issuer URL |
+| <a name="output_jwk_endpoint"></a> [jwk\_endpoint](#output\_jwk\_endpoint) | JWK endpoint for JWT validation |
+| <a name="output_token_endpoint"></a> [token\_endpoint](#output\_token\_endpoint) | OAuth2 token endpoint |
+| <a name="output_user_pool_id"></a> [user\_pool\_id](#output\_user\_pool\_id) | Cognito User Pool ID |
+<!-- END_TF_DOCS -->

--- a/modules/unreal/lore/modules/auth/lambda/pre_token_generation.mjs
+++ b/modules/unreal/lore/modules/auth/lambda/pre_token_generation.mjs
@@ -1,0 +1,17 @@
+export const handler = async (event) => {
+  const clientId = event.callerContext.clientId;
+  event.response = {
+    claimsAndScopeOverrideDetails: {
+      accessTokenGeneration: {
+        claimsToAddOrOverride: {
+          env: process.env.ENVIRONMENT || "production",
+          name: clientId,
+          preferred_username: clientId,
+          idp: "cognito",
+          resources: [{ resource_id: "urc-*", permission: [] }],
+        },
+      },
+    },
+  };
+  return event;
+};

--- a/modules/unreal/lore/modules/auth/main.tf
+++ b/modules/unreal/lore/modules/auth/main.tf
@@ -1,0 +1,104 @@
+data "aws_region" "current" {}
+
+# =============================================================================
+# Cognito User Pool — M2M auth for Lore
+# =============================================================================
+
+resource "aws_cognito_user_pool" "lore" {
+  name           = "${var.name_prefix}-auth"
+  user_pool_tier = "ESSENTIALS"
+
+  lambda_config {
+    pre_token_generation_config {
+      lambda_arn     = aws_lambda_function.pre_token.arn
+      lambda_version = "V3_0"
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_cognito_resource_server" "lore" {
+  user_pool_id = aws_cognito_user_pool.lore.id
+  identifier   = "lore"
+  name         = "Lore API"
+
+  scope {
+    scope_name        = "full_access"
+    scope_description = "Full access to Lore API"
+  }
+}
+
+resource "aws_cognito_user_pool_domain" "lore" {
+  domain       = "${var.name_prefix}-${var.environment}"
+  user_pool_id = aws_cognito_user_pool.lore.id
+}
+
+resource "aws_cognito_user_pool_client" "lore" {
+  name         = "${var.name_prefix}-client"
+  user_pool_id = aws_cognito_user_pool.lore.id
+
+  generate_secret                      = true
+  allowed_oauth_flows_user_pool_client = true
+  allowed_oauth_flows                  = ["client_credentials"]
+  allowed_oauth_scopes                 = ["lore/full_access"]
+  supported_identity_providers         = ["COGNITO"]
+
+  depends_on = [aws_cognito_resource_server.lore]
+}
+
+# =============================================================================
+# Pre-Token-Generation Lambda — injects custom claims for Lore compat
+# =============================================================================
+
+data "archive_file" "pre_token" {
+  type        = "zip"
+  source_file = "${path.module}/lambda/pre_token_generation.mjs"
+  output_path = "${path.module}/lambda/.build/pre_token_generation.zip"
+}
+
+data "aws_iam_policy_document" "lambda_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "pre_token_lambda" {
+  name_prefix        = "${var.name_prefix}-pre-token-"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "pre_token_lambda_logs" {
+  role       = aws_iam_role.pre_token_lambda.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_lambda_function" "pre_token" {
+  function_name    = "${var.name_prefix}-pre-token-gen"
+  handler          = "pre_token_generation.handler"
+  runtime          = "nodejs20.x"
+  role             = aws_iam_role.pre_token_lambda.arn
+  filename         = data.archive_file.pre_token.output_path
+  source_code_hash = data.archive_file.pre_token.output_base64sha256
+
+  environment {
+    variables = {
+      ENVIRONMENT = var.environment
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_lambda_permission" "cognito_invoke" {
+  statement_id  = "AllowCognitoInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.pre_token.function_name
+  principal     = "cognito-idp.amazonaws.com"
+  source_arn    = aws_cognito_user_pool.lore.arn
+}

--- a/modules/unreal/lore/modules/auth/outputs.tf
+++ b/modules/unreal/lore/modules/auth/outputs.tf
@@ -1,0 +1,30 @@
+output "user_pool_id" {
+  description = "Cognito User Pool ID"
+  value       = aws_cognito_user_pool.lore.id
+}
+
+output "client_id" {
+  description = "Cognito app client ID"
+  value       = aws_cognito_user_pool_client.lore.id
+}
+
+output "client_secret" {
+  description = "Cognito app client secret"
+  value       = aws_cognito_user_pool_client.lore.client_secret
+  sensitive   = true
+}
+
+output "token_endpoint" {
+  description = "OAuth2 token endpoint"
+  value       = "https://${aws_cognito_user_pool_domain.lore.domain}.auth.${data.aws_region.current.name}.amazoncognito.com/oauth2/token"
+}
+
+output "jwk_endpoint" {
+  description = "JWK endpoint for JWT validation"
+  value       = "https://cognito-idp.${data.aws_region.current.name}.amazonaws.com/${aws_cognito_user_pool.lore.id}/.well-known/jwks.json"
+}
+
+output "issuer" {
+  description = "JWT issuer URL"
+  value       = "https://cognito-idp.${data.aws_region.current.name}.amazonaws.com/${aws_cognito_user_pool.lore.id}"
+}

--- a/modules/unreal/lore/modules/auth/variables.tf
+++ b/modules/unreal/lore/modules/auth/variables.tf
@@ -1,0 +1,14 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment name (used in Cognito domain)"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+}

--- a/modules/unreal/lore/modules/auth/versions.tf
+++ b/modules/unreal/lore/modules/auth/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/modules/unreal/lore/modules/compute/README.md
+++ b/modules/unreal/lore/modules/compute/README.md
@@ -1,0 +1,142 @@
+# Compute Sub-Module
+
+Provisions ECS cluster, ASG, task definition, service, IAM roles, Cognito (optional), TLS certs, and secrets.
+
+This is an internal sub-module of `terraform-aws-lore`. Do not consume directly — use the root module.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_autoscaling_group.ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_cloudwatch_log_group.loreserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_ecs_capacity_provider.ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_capacity_provider) | resource |
+| [aws_ecs_cluster.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster) | resource |
+| [aws_ecs_cluster_capacity_providers.main](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_cluster_capacity_providers) | resource |
+| [aws_ecs_service.loreserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service) | resource |
+| [aws_ecs_task_definition.loreserver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_task_definition) | resource |
+| [aws_iam_instance_profile.ecs_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.ecs_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.xray_smoke_test](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.execution_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.otel](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.xray_smoke_test_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.ecs_instance_ecs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.ecs_instance_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.xray_smoke_test_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachments_exclusive.execution](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachments_exclusive) | resource |
+| [aws_lambda_function.xray_smoke_test](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_launch_template.ecs_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_secretsmanager_secret.hmac_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.tls_ca](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.tls_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_version.hmac_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.tls_ca](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.tls_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [random_bytes.hmac_key](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/bytes) | resource |
+| [tls_cert_request.server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
+| [tls_locally_signed_cert.server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/locally_signed_cert) | resource |
+| [tls_private_key.ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_private_key.server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_self_signed_cert.ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
+| [archive_file.xray_smoke_test](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_iam_policy_document.ec2_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecs_task_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.execution_secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.otel_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.task_permissions](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.xray_smoke_test_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.xray_smoke_test_xray](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_ssm_parameter.ecs_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_container_image"></a> [container\_image](#input\_container\_image) | Loreserver container image URI | `string` | n/a | yes |
+| <a name="input_dynamodb_table_arns"></a> [dynamodb\_table\_arns](#input\_dynamodb\_table\_arns) | List of DynamoDB table ARNs for IAM policy | `list(string)` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | Environment name (dev, staging, prod) — used for ASG defaults | `string` | n/a | yes |
+| <a name="input_fragment_bucket_arn"></a> [fragment\_bucket\_arn](#input\_fragment\_bucket\_arn) | ARN of the S3 fragment bucket | `string` | n/a | yes |
+| <a name="input_fragment_bucket_name"></a> [fragment\_bucket\_name](#input\_fragment\_bucket\_name) | S3 fragment bucket name (for LORE\_\_* env vars) | `string` | n/a | yes |
+| <a name="input_fragment_metadata_table_name"></a> [fragment\_metadata\_table\_name](#input\_fragment\_metadata\_table\_name) | DynamoDB fragment metadata table name | `string` | n/a | yes |
+| <a name="input_fragments_table_name"></a> [fragments\_table\_name](#input\_fragments\_table\_name) | DynamoDB fragments table name | `string` | n/a | yes |
+| <a name="input_locks_table_arn"></a> [locks\_table\_arn](#input\_locks\_table\_arn) | ARN of the locks DynamoDB table (for GSI access) | `string` | n/a | yes |
+| <a name="input_locks_table_name"></a> [locks\_table\_name](#input\_locks\_table\_name) | DynamoDB locks table name | `string` | n/a | yes |
+| <a name="input_mutable_store_table_name"></a> [mutable\_store\_table\_name](#input\_mutable\_store\_table\_name) | DynamoDB mutable store table name | `string` | n/a | yes |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all resource names | `string` | n/a | yes |
+| <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | Private subnet IDs for ASG instances | `list(string)` | n/a | yes |
+| <a name="input_server_security_group_id"></a> [server\_security\_group\_id](#input\_server\_security\_group\_id) | Security group ID for Lore server instances | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | n/a | yes |
+| <a name="input_write_tier_dns_name"></a> [write\_tier\_dns\_name](#input\_write\_tier\_dns\_name) | Cloud Map DNS name (included in self-signed cert SAN) | `string` | n/a | yes |
+| <a name="input_ami_id"></a> [ami\_id](#input\_ami\_id) | AMI ID override. If null, uses latest ECS-optimized AL2023. | `string` | `null` | no |
+| <a name="input_asg_desired_size"></a> [asg\_desired\_size](#input\_asg\_desired\_size) | ASG desired capacity. Null = environment-aware default (dev:0, staging:1, prod:1) | `number` | `null` | no |
+| <a name="input_asg_max_size"></a> [asg\_max\_size](#input\_asg\_max\_size) | ASG maximum size. Null = environment-aware default (dev:1, staging:1, prod:3) | `number` | `null` | no |
+| <a name="input_asg_min_size"></a> [asg\_min\_size](#input\_asg\_min\_size) | ASG minimum size. Null = environment-aware default (dev:0, staging:0, prod:1) | `number` | `null` | no |
+| <a name="input_auth_jwk_endpoint"></a> [auth\_jwk\_endpoint](#input\_auth\_jwk\_endpoint) | JWK endpoint URL (required when auth\_mode = 'external') | `string` | `null` | no |
+| <a name="input_auth_jwt_audience"></a> [auth\_jwt\_audience](#input\_auth\_jwt\_audience) | JWT audience values the server accepts | `list(string)` | `[]` | no |
+| <a name="input_auth_jwt_issuer"></a> [auth\_jwt\_issuer](#input\_auth\_jwt\_issuer) | JWT issuer string (required when auth\_mode = 'external') | `string` | `null` | no |
+| <a name="input_auth_mode"></a> [auth\_mode](#input\_auth\_mode) | Authentication mode: 'none' (open access), 'cognito' (AWS-native M2M), 'external' (bring your own IdP) | `string` | `"none"` | no |
+| <a name="input_cache_max_size_bytes"></a> [cache\_max\_size\_bytes](#input\_cache\_max\_size\_bytes) | NVMe cache maximum size in bytes. 0 = auto-size to 80% of instance store capacity. | `number` | `0` | no |
+| <a name="input_container_memory_reservation"></a> [container\_memory\_reservation](#input\_container\_memory\_reservation) | Soft memory reservation (MiB) for the loreserver container. If null, auto-sizes based on instance type. | `number` | `null` | no |
+| <a name="input_container_user"></a> [container\_user](#input\_container\_user) | User/group for the container process (e.g., '65534', '1000:1000'). Must be numeric UID or UID:GID. | `string` | `"65534"` | no |
+| <a name="input_deployment_maximum_percent"></a> [deployment\_maximum\_percent](#input\_deployment\_maximum\_percent) | Upper limit on running tasks during deployment (% of desired\_count). | `number` | `200` | no |
+| <a name="input_deployment_minimum_healthy_percent"></a> [deployment\_minimum\_healthy\_percent](#input\_deployment\_minimum\_healthy\_percent) | Lower limit on running tasks during deployment (% of desired\_count). Default 66 allows single-task services to deploy without ENI deadlock. | `number` | `66` | no |
+| <a name="input_enable_otel_sidecar"></a> [enable\_otel\_sidecar](#input\_enable\_otel\_sidecar) | Deploy ADOT sidecar for OpenTelemetry collection (CloudWatch + X-Ray) | `bool` | `true` | no |
+| <a name="input_enable_replication"></a> [enable\_replication](#input\_enable\_replication) | Enable the QUIC internal replication endpoint (port 41340). Required for multi-server cache topologies. | `bool` | `false` | no |
+| <a name="input_enable_xray_smoke_test"></a> [enable\_xray\_smoke\_test](#input\_enable\_xray\_smoke\_test) | Deploy X-Ray pipeline smoke test Lambda (validates trace delivery + IAM) | `bool` | `true` | no |
+| <a name="input_hmac_key_secret_arn"></a> [hmac\_key\_secret\_arn](#input\_hmac\_key\_secret\_arn) | Secrets Manager ARN for HMAC signing key. If null, a random 32-byte key is generated. | `string` | `null` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type for ECS instances. Unknown types fall back to 28 GiB memory reservation and 937 GB cache size. | `string` | `"i4i.xlarge"` | no |
+| <a name="input_log_retention_days"></a> [log\_retention\_days](#input\_log\_retention\_days) | CloudWatch log group retention in days. Valid values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653. | `number` | `30` | no |
+| <a name="input_otel_collector_image"></a> [otel\_collector\_image](#input\_otel\_collector\_image) | ADOT collector image URI. Override to use a private ECR mirror. | `string` | `"public.ecr.aws/aws-observability/aws-otel-collector:latest"` | no |
+| <a name="input_replication_peers"></a> [replication\_peers](#input\_replication\_peers) | List of peer addresses for fixed topology replication. Each entry is a host:port string (e.g., '10.0.1.50:41340'). | `list(string)` | `[]` | no |
+| <a name="input_service_discovery_registry_arn"></a> [service\_discovery\_registry\_arn](#input\_service\_discovery\_registry\_arn) | Cloud Map service ARN for ECS service registration. Null when service discovery is disabled. | `string` | `null` | no |
+| <a name="input_tls_certificate_secret_arn"></a> [tls\_certificate\_secret\_arn](#input\_tls\_certificate\_secret\_arn) | Secrets Manager ARN for server TLS certificate. If null, a self-signed cert is generated. | `string` | `null` | no |
+| <a name="input_tls_private_key_secret_arn"></a> [tls\_private\_key\_secret\_arn](#input\_tls\_private\_key\_secret\_arn) | Secrets Manager ARN for server TLS private key. If null, generated with self-signed cert. | `string` | `null` | no |
+| <a name="input_tls_san_dns_names"></a> [tls\_san\_dns\_names](#input\_tls\_san\_dns\_names) | Additional DNS SANs for the self-signed TLS certificate (e.g., custom domain names) | `list(string)` | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_cache_max_size_bytes"></a> [cache\_max\_size\_bytes](#output\_cache\_max\_size\_bytes) | Auto-calculated NVMe cache size in bytes (80% of instance store) |
+| <a name="output_capacity_provider_name"></a> [capacity\_provider\_name](#output\_capacity\_provider\_name) | Name of the EC2 capacity provider |
+| <a name="output_cpu_architecture"></a> [cpu\_architecture](#output\_cpu\_architecture) | CPU architecture for ECS tasks (ARM64 or X86\_64) |
+| <a name="output_ecs_cluster_arn"></a> [ecs\_cluster\_arn](#output\_ecs\_cluster\_arn) | ARN of the ECS cluster |
+| <a name="output_ecs_cluster_name"></a> [ecs\_cluster\_name](#output\_ecs\_cluster\_name) | Name of the ECS cluster |
+| <a name="output_effective_asg_config"></a> [effective\_asg\_config](#output\_effective\_asg\_config) | Resolved ASG sizing after environment-aware defaults |
+| <a name="output_execution_role_arn"></a> [execution\_role\_arn](#output\_execution\_role\_arn) | ARN of the ECS execution IAM role |
+| <a name="output_service_name"></a> [service\_name](#output\_service\_name) | Name of the ECS service |
+| <a name="output_task_definition_arn"></a> [task\_definition\_arn](#output\_task\_definition\_arn) | ARN of the loreserver task definition |
+| <a name="output_task_role_arn"></a> [task\_role\_arn](#output\_task\_role\_arn) | ARN of the ECS task IAM role |
+| <a name="output_tls_ca_cert_pem"></a> [tls\_ca\_cert\_pem](#output\_tls\_ca\_cert\_pem) | CA certificate PEM for client trust configuration. Null when using external certs. |
+<!-- END_TF_DOCS -->

--- a/modules/unreal/lore/modules/compute/asg.tf
+++ b/modules/unreal/lore/modules/compute/asg.tf
@@ -1,0 +1,93 @@
+data "aws_ssm_parameter" "ecs_ami" {
+  name = "/aws/service/ecs/optimized-ami/amazon-linux-2023${local.is_arm64 ? "/arm64" : ""}/recommended/image_id"
+}
+
+locals {
+  # Detect ARM64 (Graviton) instances by family prefix
+  instance_family = split(".", var.instance_type)[0]
+  is_arm64        = contains(["c8gd", "c8g", "c7gd", "c7g", "c7gn", "m7g", "m7gd", "m8g", "r7g", "r7gd", "r8g", "t4g", "im4gn", "is4gen", "x2gd", "hpc7g"], local.instance_family)
+
+  ami_id = var.ami_id != null ? var.ami_id : data.aws_ssm_parameter.ecs_ami.value
+  asg_min_size = var.asg_min_size != null ? var.asg_min_size : (
+    var.environment == "prod" ? 1 : 0
+  )
+  asg_max_size = var.asg_max_size != null ? var.asg_max_size : (
+    var.environment == "prod" ? 3 : 1
+  )
+  asg_desired_size = var.asg_desired_size != null ? var.asg_desired_size : (
+    var.environment == "prod" ? 1 : (var.environment == "staging" ? 1 : 0)
+  )
+}
+
+resource "aws_launch_template" "ecs_instance" {
+  name_prefix   = "${var.name_prefix}-ecs-"
+  image_id      = local.ami_id
+  instance_type = var.instance_type
+
+  iam_instance_profile {
+    arn = aws_iam_instance_profile.ecs_instance.arn
+  }
+
+  vpc_security_group_ids = [var.server_security_group_id]
+
+  user_data = base64encode(templatefile("${path.module}/templates/user_data.sh", {
+    cluster_name  = aws_ecs_cluster.main.name
+    mount_path    = "/srv/urc"
+    container_uid = var.container_user
+  }))
+
+  metadata_options {
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 1
+  }
+
+  tag_specifications {
+    resource_type = "instance"
+    tags          = merge(var.tags, { Name = "${var.name_prefix}-ecs-instance" })
+  }
+
+  tags = var.tags
+}
+
+resource "aws_autoscaling_group" "ecs" {
+  name_prefix         = "${var.name_prefix}-ecs-"
+  min_size            = local.asg_min_size
+  max_size            = local.asg_max_size
+  desired_capacity    = local.asg_desired_size
+  vpc_zone_identifier = var.private_subnet_ids
+
+  launch_template {
+    id      = aws_launch_template.ecs_instance.id
+    version = "$Latest"
+  }
+
+  # Prevent ASG from terminating instances with running tasks
+  protect_from_scale_in = true
+
+  # Allow Terraform to delete the ASG without waiting for instance termination.
+  # Only affects `terraform destroy` — normal scaling operations are unaffected.
+  # Without this, destroy blocks waiting for capacity provider to release
+  # termination protection (15+ min due to target tracking alarm evaluation).
+  force_delete = true
+
+  tag {
+    key                 = "AmazonECSManaged"
+    value               = "true"
+    propagate_at_launch = true
+  }
+
+  dynamic "tag" {
+    for_each = var.tags
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
+  lifecycle {
+    # ECS managed scaling adjusts desired_capacity externally; prevent Terraform from reverting
+    ignore_changes = [desired_capacity]
+  }
+}

--- a/modules/unreal/lore/modules/compute/cluster.tf
+++ b/modules/unreal/lore/modules/compute/cluster.tf
@@ -1,0 +1,38 @@
+resource "aws_ecs_cluster" "main" {
+  name = "${var.name_prefix}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_capacity_provider" "ec2" {
+  name = "${var.name_prefix}-ec2"
+
+  auto_scaling_group_provider {
+    auto_scaling_group_arn         = aws_autoscaling_group.ecs.arn
+    managed_termination_protection = "ENABLED"
+
+    managed_scaling {
+      status                    = "ENABLED"
+      target_capacity           = 100
+      minimum_scaling_step_size = 1
+      maximum_scaling_step_size = 1
+    }
+  }
+
+  tags = var.tags
+}
+
+resource "aws_ecs_cluster_capacity_providers" "main" {
+  cluster_name       = aws_ecs_cluster.main.name
+  capacity_providers = [aws_ecs_capacity_provider.ec2.name]
+
+  default_capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.ec2.name
+    weight            = 100
+  }
+}

--- a/modules/unreal/lore/modules/compute/iam.tf
+++ b/modules/unreal/lore/modules/compute/iam.tf
@@ -1,0 +1,143 @@
+data "aws_iam_policy_document" "ecs_task_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+# =============================================================================
+# Task Role — application permissions (S3 + DynamoDB + ADOT)
+# =============================================================================
+
+resource "aws_iam_role" "task" {
+  name_prefix        = "${var.name_prefix}-task-"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+  tags               = var.tags
+}
+
+data "aws_iam_policy_document" "task_permissions" {
+  statement {
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:DeleteObject",
+      "s3:ListBucket",
+      "s3:HeadObject",
+      "s3:HeadBucket",
+      "s3:ListObjectVersions",
+      "s3:AbortMultipartUpload",
+      "s3:ListMultipartUploadParts",
+    ]
+    resources = [
+      var.fragment_bucket_arn,
+      "${var.fragment_bucket_arn}/*",
+    ]
+  }
+
+  statement {
+    actions = [
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem",
+      "dynamodb:Query",
+      "dynamodb:BatchGetItem",
+      "dynamodb:DescribeTable",
+      "dynamodb:TransactWriteItems",
+    ]
+    resources = var.dynamodb_table_arns
+  }
+
+  statement {
+    actions   = ["dynamodb:Query"]
+    resources = ["${var.locks_table_arn}/index/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "task" {
+  name_prefix = "${var.name_prefix}-task-"
+  role        = aws_iam_role.task.id
+  policy      = data.aws_iam_policy_document.task_permissions.json
+}
+
+# ADOT permissions (on task role — all containers share it)
+data "aws_iam_policy_document" "otel_permissions" {
+  count = var.enable_otel_sidecar ? 1 : 0
+
+  # X-Ray trace submission + sampling config retrieval.
+  # These actions do NOT support resource-level ARNs (IAM reference: Resource types column
+  # is empty). No useful condition keys exist for the ECS sidecar pattern.
+  # See: https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsx-ray.html
+  statement {
+    sid = "XRayTraceSubmission"
+    actions = [
+      "xray:PutTraceSegments",
+      "xray:PutTelemetryRecords",
+      "xray:GetSamplingRules",
+      "xray:GetSamplingTargets",
+    ]
+    resources = ["*"]
+  }
+
+  # CloudWatch Logs — scoped to the specific log group created by this module.
+  # CreateLogGroup omitted: Terraform creates the log group; ADOT doesn't need to.
+  # PutMetricData omitted: ecs-xray.yaml has no metrics exporter (only awsxray).
+  # If switching to ecs-cloudwatch-xray.yaml, add PutMetricData with cloudwatch:namespace condition.
+  statement {
+    sid = "CloudWatchLogs"
+    actions = [
+      "logs:PutLogEvents",
+      "logs:CreateLogStream",
+      "logs:DescribeLogStreams",
+      "logs:DescribeLogGroups",
+    ]
+    resources = [
+      aws_cloudwatch_log_group.loreserver.arn,
+      "${aws_cloudwatch_log_group.loreserver.arn}:*",
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "otel" {
+  count       = var.enable_otel_sidecar ? 1 : 0
+  name_prefix = "${var.name_prefix}-otel-"
+  role        = aws_iam_role.task.id
+  policy      = data.aws_iam_policy_document.otel_permissions[0].json
+}
+
+# =============================================================================
+# Execution Role — ECS infrastructure permissions (ECR pull + logs + secrets)
+# =============================================================================
+
+resource "aws_iam_role" "execution" {
+  name_prefix        = "${var.name_prefix}-exec-"
+  assume_role_policy = data.aws_iam_policy_document.ecs_task_assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachments_exclusive" "execution" {
+  role_name = aws_iam_role.execution.name
+  policy_arns = [
+    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+  ]
+}
+
+data "aws_iam_policy_document" "execution_secrets" {
+  statement {
+    actions = ["secretsmanager:GetSecretValue"]
+    resources = compact([
+      local.tls_cert_secret_arn,
+      local.tls_key_secret_arn,
+      local.hmac_key_secret_arn,
+      local.tls_ca_secret_arn,
+    ])
+  }
+}
+
+resource "aws_iam_role_policy" "execution_secrets" {
+  name_prefix = "${var.name_prefix}-exec-secrets-"
+  role        = aws_iam_role.execution.id
+  policy      = data.aws_iam_policy_document.execution_secrets.json
+}

--- a/modules/unreal/lore/modules/compute/instance_profile.tf
+++ b/modules/unreal/lore/modules/compute/instance_profile.tf
@@ -1,0 +1,31 @@
+data "aws_iam_policy_document" "ec2_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "ecs_instance" {
+  name_prefix        = "${var.name_prefix}-ecs-inst-"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_ecs" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role"
+}
+
+resource "aws_iam_role_policy_attachment" "ecs_instance_ssm" {
+  role       = aws_iam_role.ecs_instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "ecs_instance" {
+  name_prefix = "${var.name_prefix}-ecs-inst-"
+  role        = aws_iam_role.ecs_instance.name
+  tags        = var.tags
+}

--- a/modules/unreal/lore/modules/compute/lambda/xray_smoke_test.mjs
+++ b/modules/unreal/lore/modules/compute/lambda/xray_smoke_test.mjs
@@ -1,0 +1,54 @@
+// X-Ray pipeline smoke test — sends a synthetic trace segment and verifies arrival.
+// Validates: IAM permissions (xray:PutTraceSegments, xray:GetTraceSummaries), X-Ray reachability.
+// ADOT Sidecar health is verified separately via CloudWatch logs ("Everything is ready").
+import { XRayClient, PutTraceSegmentsCommand, GetTraceSummariesCommand } from "@aws-sdk/client-xray";
+
+const xray = new XRayClient();
+
+export const handler = async () => {
+  const now = Date.now() / 1000;
+  const hex = (n) => Math.floor(n).toString(16);
+  const rand = (len) => Array.from(crypto.getRandomValues(new Uint8Array(len)), (b) => b.toString(16).padStart(2, "0")).join("");
+  const traceId = `1-${hex(now)}-${rand(12)}`;
+  const segmentId = rand(8);
+
+  const segment = JSON.stringify({
+    name: "lore-xray-smoke-test",
+    id: segmentId,
+    trace_id: traceId,
+    start_time: now,
+    end_time: now + 0.05,
+    annotations: { test: "smoke", environment: process.env.ENVIRONMENT || "dev" },
+  });
+
+  try {
+    await xray.send(new PutTraceSegmentsCommand({ TraceSegmentDocuments: [segment] }));
+  } catch (e) {
+    return { status: "FAIL", phase: "put", error: e.message };
+  }
+
+  await new Promise((r) => setTimeout(r, 6000));
+
+  try {
+    const startTime = new Date((now - 30) * 1000);
+    const endTime = new Date((now + 30) * 1000);
+    const res = await xray.send(new GetTraceSummariesCommand({
+      StartTime: startTime,
+      EndTime: endTime,
+      FilterExpression: 'annotation.test = "smoke"',
+    }));
+
+    const found = (res.TraceSummaries || []).some((t) => t.Id === traceId);
+    return {
+      status: found ? "PASS" : "WARN",
+      traceId,
+      found,
+      summaryCount: (res.TraceSummaries || []).length,
+      message: found
+        ? "Trace arrived in X-Ray — pipeline verified."
+        : "Trace sent but not yet visible (may need more propagation time).",
+    };
+  } catch (e) {
+    return { status: "FAIL", phase: "get", error: e.message };
+  }
+};

--- a/modules/unreal/lore/modules/compute/locals.tf
+++ b/modules/unreal/lore/modules/compute/locals.tf
@@ -1,0 +1,62 @@
+locals {
+  # Instance memory lookup (MiB). Covers common ECS instance types.
+  # Reserve ~90% of instance memory for the container (OS + ECS agent + sidecars use the rest).
+  instance_memory_map = {
+    "t3.medium"     = 3072
+    "t3.large"      = 6144
+    "t3.xlarge"     = 13312
+    "t3.2xlarge"    = 28672
+    "m5.large"      = 6144
+    "m5.xlarge"     = 13312
+    "m5.2xlarge"    = 28672
+    "c8gd.xlarge"   = 6144
+    "c8gd.2xlarge"  = 13312
+    "c8gd.4xlarge"  = 28672
+    "c8gd.8xlarge"  = 59392
+    "c8gd.12xlarge" = 88064
+    "c8gd.16xlarge" = 118784
+    "i3en.large"    = 13312
+    "i3en.xlarge"   = 28672
+    "i4i.large"     = 13312
+    "i4i.xlarge"    = 28672
+    "i4i.2xlarge"   = 59392
+  }
+
+  container_memory_reservation = coalesce(
+    var.container_memory_reservation,
+    lookup(local.instance_memory_map, var.instance_type, 28672)
+  )
+
+  # Instance store total capacity in bytes (from AWS docs).
+  # Used to auto-size cache_max_size when var.cache_max_size_bytes = 0.
+  instance_store_bytes = {
+    "t3.medium"     = 0             # No instance store
+    "t3.large"      = 0             # No instance store
+    "t3.xlarge"     = 0             # No instance store
+    "t3.2xlarge"    = 0             # No instance store
+    "m5.large"      = 0             # No instance store
+    "m5.xlarge"     = 0             # No instance store
+    "m5.2xlarge"    = 0             # No instance store
+    "c8gd.xlarge"   = 237000000000  # 237 GB (1× NVMe)
+    "c8gd.2xlarge"  = 474000000000  # 474 GB (1× NVMe)
+    "c8gd.4xlarge"  = 950000000000  # 950 GB (1× NVMe)
+    "c8gd.8xlarge"  = 1900000000000 # 1.9 TB (1× NVMe)
+    "c8gd.12xlarge" = 2850000000000 # 2.85 TB (3× NVMe)
+    "c8gd.16xlarge" = 3800000000000 # 3.8 TB (2× NVMe)
+    "i3en.large"    = 1250000000000 # 1.25 TB (1× NVMe)
+    "i3en.xlarge"   = 2500000000000 # 2.5 TB (1× NVMe)
+    "i3en.2xlarge"  = 5000000000000 # 5 TB (2× NVMe)
+    "i4i.large"     = 468000000000  # 468 GB (1× NVMe)
+    "i4i.xlarge"    = 937000000000  # 937 GB (1× NVMe)
+    "i4i.2xlarge"   = 1875000000000 # 1.875 TB (1× NVMe)
+    "i4i.4xlarge"   = 3750000000000 # 3.75 TB (2× NVMe)
+    "r6id.xlarge"   = 237000000000  # 237 GB (1× NVMe)
+    "r6id.2xlarge"  = 474000000000  # 474 GB (2× NVMe)
+  }
+
+  # 80% of total instance store, or explicit user override.
+  # Falls back to 937 GB (i4i.xlarge default) for unknown instance types.
+  cache_max_size = var.cache_max_size_bytes > 0 ? var.cache_max_size_bytes : (
+    floor(lookup(local.instance_store_bytes, var.instance_type, 937000000000) * 0.8)
+  )
+}

--- a/modules/unreal/lore/modules/compute/logs.tf
+++ b/modules/unreal/lore/modules/compute/logs.tf
@@ -1,0 +1,5 @@
+resource "aws_cloudwatch_log_group" "loreserver" {
+  name              = "/ecs/${var.name_prefix}-loreserver"
+  retention_in_days = var.log_retention_days
+  tags              = var.tags
+}

--- a/modules/unreal/lore/modules/compute/outputs.tf
+++ b/modules/unreal/lore/modules/compute/outputs.tf
@@ -1,0 +1,62 @@
+output "task_role_arn" {
+  description = "ARN of the ECS task IAM role"
+  value       = aws_iam_role.task.arn
+}
+
+output "execution_role_arn" {
+  description = "ARN of the ECS execution IAM role"
+  value       = aws_iam_role.execution.arn
+}
+
+output "ecs_cluster_name" {
+  description = "Name of the ECS cluster"
+  value       = aws_ecs_cluster.main.name
+}
+
+output "ecs_cluster_arn" {
+  description = "ARN of the ECS cluster"
+  value       = aws_ecs_cluster.main.arn
+}
+
+output "capacity_provider_name" {
+  description = "Name of the EC2 capacity provider"
+  value       = aws_ecs_capacity_provider.ec2.name
+}
+
+output "service_name" {
+  description = "Name of the ECS service"
+  value       = aws_ecs_service.loreserver.name
+}
+
+output "task_definition_arn" {
+  description = "ARN of the loreserver task definition"
+  value       = aws_ecs_task_definition.loreserver.arn
+}
+
+# =============================================================================
+# Phase 6: Security & Observability
+# =============================================================================
+
+output "tls_ca_cert_pem" {
+  description = "CA certificate PEM for client trust configuration. Null when using external certs."
+  value       = try(tls_self_signed_cert.ca[0].cert_pem, null)
+}
+
+output "effective_asg_config" {
+  description = "Resolved ASG sizing after environment-aware defaults"
+  value = {
+    min_size     = aws_autoscaling_group.ecs.min_size
+    max_size     = aws_autoscaling_group.ecs.max_size
+    desired_size = aws_autoscaling_group.ecs.desired_capacity
+  }
+}
+
+output "cpu_architecture" {
+  description = "CPU architecture for ECS tasks (ARM64 or X86_64)"
+  value       = local.is_arm64 ? "ARM64" : "X86_64"
+}
+
+output "cache_max_size_bytes" {
+  description = "Auto-calculated NVMe cache size in bytes (80% of instance store)"
+  value       = local.cache_max_size
+}

--- a/modules/unreal/lore/modules/compute/secrets.tf
+++ b/modules/unreal/lore/modules/compute/secrets.tf
@@ -1,0 +1,121 @@
+# =============================================================================
+# TLS Certificate — CA + server cert fallback when no external cert ARN provided
+# =============================================================================
+
+# --- CA (trust anchor) ---
+resource "tls_private_key" "ca" {
+  count       = var.tls_certificate_secret_arn == null ? 1 : 0
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
+}
+
+resource "tls_self_signed_cert" "ca" {
+  count                 = var.tls_certificate_secret_arn == null ? 1 : 0
+  private_key_pem       = tls_private_key.ca[0].private_key_pem
+  validity_period_hours = 8760
+  is_ca_certificate     = true
+
+  subject { common_name = "Lore Internal CA" }
+
+  allowed_uses = ["digital_signature", "cert_signing", "crl_signing"]
+}
+
+# --- Server cert (signed by CA) ---
+resource "tls_private_key" "server" {
+  count       = var.tls_private_key_secret_arn == null ? 1 : 0
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
+}
+
+resource "tls_cert_request" "server" {
+  count           = var.tls_certificate_secret_arn == null ? 1 : 0
+  private_key_pem = tls_private_key.server[0].private_key_pem
+
+  subject { common_name = "loreserver.internal" }
+
+  dns_names = concat(
+    ["loreserver.internal", "localhost"],
+    compact([var.write_tier_dns_name]),
+    var.tls_san_dns_names
+  )
+  ip_addresses = ["127.0.0.1"]
+}
+
+resource "tls_locally_signed_cert" "server" {
+  count              = var.tls_certificate_secret_arn == null ? 1 : 0
+  cert_request_pem   = tls_cert_request.server[0].cert_request_pem
+  ca_private_key_pem = tls_private_key.ca[0].private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.ca[0].cert_pem
+
+  validity_period_hours = 8760
+
+  allowed_uses = ["digital_signature", "key_encipherment", "server_auth"]
+}
+
+resource "aws_secretsmanager_secret" "tls_cert" {
+  count       = var.tls_certificate_secret_arn == null ? 1 : 0
+  name_prefix = "${var.name_prefix}-tls-cert-"
+  tags        = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "tls_cert" {
+  count         = var.tls_certificate_secret_arn == null ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.tls_cert[0].id
+  secret_string = tls_locally_signed_cert.server[0].cert_pem
+}
+
+resource "aws_secretsmanager_secret" "tls_ca" {
+  count       = var.tls_certificate_secret_arn == null ? 1 : 0
+  name_prefix = "${var.name_prefix}-tls-ca-"
+  tags        = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "tls_ca" {
+  count         = var.tls_certificate_secret_arn == null ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.tls_ca[0].id
+  secret_string = tls_self_signed_cert.ca[0].cert_pem
+}
+
+resource "aws_secretsmanager_secret" "tls_key" {
+  count       = var.tls_private_key_secret_arn == null ? 1 : 0
+  name_prefix = "${var.name_prefix}-tls-key-"
+  tags        = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "tls_key" {
+  count         = var.tls_private_key_secret_arn == null ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.tls_key[0].id
+  secret_string = tls_private_key.server[0].private_key_pem
+}
+
+# =============================================================================
+# HMAC Key — replaces hardcoded hex value
+# =============================================================================
+
+resource "random_bytes" "hmac_key" {
+  count  = var.hmac_key_secret_arn == null ? 1 : 0
+  length = 32
+}
+
+resource "aws_secretsmanager_secret" "hmac_key" {
+  count       = var.hmac_key_secret_arn == null ? 1 : 0
+  name_prefix = "${var.name_prefix}-hmac-"
+  tags        = var.tags
+}
+
+resource "aws_secretsmanager_secret_version" "hmac_key" {
+  count         = var.hmac_key_secret_arn == null ? 1 : 0
+  secret_id     = aws_secretsmanager_secret.hmac_key[0].id
+  secret_string = random_bytes.hmac_key[0].hex
+}
+
+# =============================================================================
+# Locals — resolve final ARNs (user-provided or generated)
+# =============================================================================
+
+locals {
+  tls_cert_secret_arn = coalesce(var.tls_certificate_secret_arn, try(aws_secretsmanager_secret.tls_cert[0].arn, ""))
+  tls_ca_secret_arn   = try(aws_secretsmanager_secret.tls_ca[0].arn, "")
+  tls_key_secret_arn  = coalesce(var.tls_private_key_secret_arn, try(aws_secretsmanager_secret.tls_key[0].arn, ""))
+  hmac_key_secret_arn = coalesce(var.hmac_key_secret_arn, try(aws_secretsmanager_secret.hmac_key[0].arn, ""))
+}

--- a/modules/unreal/lore/modules/compute/service.tf
+++ b/modules/unreal/lore/modules/compute/service.tf
@@ -1,0 +1,44 @@
+locals {
+  # ECS service drain with capacity provider managed termination protection:
+  # task stop + ECS state machine polling (~2-4 min) +
+  # capacity provider reconciliation (~2-5 min) + ASG scale-in signal (~1-2 min).
+  # Observed: dev takes ~8-12min. Buffer generously to avoid two-pass destroys.
+  service_delete_timeout = 900
+}
+
+resource "aws_ecs_service" "loreserver" {
+  name            = "${var.name_prefix}-loreserver"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.loreserver.arn
+  desired_count   = local.asg_desired_size
+
+  deployment_minimum_healthy_percent = var.deployment_minimum_healthy_percent
+  deployment_maximum_percent         = var.deployment_maximum_percent
+
+  capacity_provider_strategy {
+    capacity_provider = aws_ecs_capacity_provider.ec2.name
+    weight            = 100
+  }
+
+  network_configuration {
+    subnets         = var.private_subnet_ids
+    security_groups = [var.server_security_group_id]
+  }
+
+  dynamic "service_registries" {
+    for_each = var.service_discovery_registry_arn != null ? [1] : []
+    content {
+      registry_arn = var.service_discovery_registry_arn
+    }
+  }
+
+  placement_constraints {
+    type = "distinctInstance"
+  }
+
+  timeouts {
+    delete = "${local.service_delete_timeout}s"
+  }
+
+  tags = var.tags
+}

--- a/modules/unreal/lore/modules/compute/task_definition.tf
+++ b/modules/unreal/lore/modules/compute/task_definition.tf
@@ -1,0 +1,162 @@
+data "aws_region" "current" {}
+
+locals {
+  # Auth env vars — set when auth_mode != "none" and jwk_endpoint is provided
+  auth_env_vars = var.auth_mode != "none" && var.auth_jwk_endpoint != null ? [
+    { name = "LORE__SERVER__AUTH__JWK__ENDPOINT", value = var.auth_jwk_endpoint },
+    { name = "LORE__SERVER__AUTH__JWT_ISSUER", value = var.auth_jwt_issuer },
+  ] : []
+
+  auth_audience_env = length(var.auth_jwt_audience) > 0 ? [
+    { name = "LORE__SERVER__AUTH__JWT_AUDIENCE", value = join(",", var.auth_jwt_audience) }
+  ] : []
+
+  # Replication env vars — conditional on enable_replication
+  replication_env_vars = var.enable_replication ? concat([
+    { name = "LORE__SERVER__QUIC_INTERNAL__ENABLED", value = "true" },
+    { name = "LORE__SERVER__QUIC_INTERNAL__PORT", value = "41340" },
+    { name = "LORE__SERVER__QUIC_INTERNAL__CERTIFICATE__CERT_FILE", value = "/certs/fullchain.crt" },
+    { name = "LORE__SERVER__QUIC_INTERNAL__CERTIFICATE__PKEY_FILE", value = "/certs/server.key" },
+    { name = "LORE__SERVER__QUIC_INTERNAL__VERIFY_CLIENT_CERTS", value = "false" },
+    ], length(var.replication_peers) > 0 ? [
+    { name = "LORE__TOPOLOGY__PROVIDER", value = "fixed" },
+    { name = "LORE__TOPOLOGY__FIXED__PEERS", value = jsonencode([for peer in var.replication_peers : { address = split(":", peer)[0], port = tonumber(split(":", peer)[1]), locality = "same_region" }]) },
+  ] : []) : []
+
+  # ADOT sidecar container definition
+  otel_container = var.enable_otel_sidecar ? [{
+    name              = "aws-otel-collector"
+    image             = var.otel_collector_image
+    essential         = false
+    command           = ["--config=/etc/ecs/ecs-xray.yaml"]
+    memoryReservation = 256
+    healthCheck = {
+      command     = ["CMD", "/healthcheck"]
+      interval    = 5
+      timeout     = 6
+      retries     = 5
+      startPeriod = 1
+    }
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = aws_cloudwatch_log_group.loreserver.name
+        "awslogs-region"        = data.aws_region.current.name
+        "awslogs-stream-prefix" = "otel"
+      }
+    }
+  }] : []
+}
+
+resource "aws_ecs_task_definition" "loreserver" {
+  family                   = "${var.name_prefix}-loreserver"
+  requires_compatibilities = ["EC2"]
+  network_mode             = "awsvpc"
+  task_role_arn            = aws_iam_role.task.arn
+  execution_role_arn       = aws_iam_role.execution.arn
+
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = local.is_arm64 ? "ARM64" : "X86_64"
+  }
+
+  volume {
+    name      = "instance-store-cache"
+    host_path = "/srv/urc"
+  }
+
+  volume {
+    name = "certs"
+  }
+
+  container_definitions = jsonencode(concat(
+    # Init container — writes TLS certs to shared volume
+    [{
+      name              = "init-certs"
+      image             = "public.ecr.aws/docker/library/busybox:stable"
+      essential         = false
+      command           = ["sh", "-c", "echo \"$TLS_CERT\" > /certs/server.crt && echo \"$TLS_KEY\" > /certs/server.key && echo \"$TLS_CA\" > /certs/ca.crt && cat /certs/server.crt /certs/ca.crt > /certs/fullchain.crt && chown 65534:65534 /certs/server.key && chmod 600 /certs/server.key && chmod 644 /certs/server.crt /certs/ca.crt /certs/fullchain.crt"]
+      memoryReservation = 32
+
+      secrets = [
+        { name = "TLS_CERT", valueFrom = local.tls_cert_secret_arn },
+        { name = "TLS_KEY", valueFrom = local.tls_key_secret_arn },
+        { name = "TLS_CA", valueFrom = local.tls_ca_secret_arn },
+      ]
+
+      mountPoints = [{ sourceVolume = "certs", containerPath = "/certs", readOnly = false }]
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.loreserver.name
+          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-stream-prefix" = "init-certs"
+        }
+      }
+    }],
+
+    # Main loreserver container
+    [{
+      name              = "loreserver"
+      image             = var.container_image
+      user              = var.container_user
+      memoryReservation = local.container_memory_reservation
+
+      dependsOn = [{ containerName = "init-certs", condition = "SUCCESS" }]
+
+      portMappings = concat([
+        { containerPort = 41337, protocol = "tcp" },
+        { containerPort = 41339, protocol = "tcp" },
+        ], var.enable_replication ? [
+        { containerPort = 41340, protocol = "tcp" },
+      ] : [])
+
+      mountPoints = [
+        { sourceVolume = "instance-store-cache", containerPath = "/srv/urc", readOnly = false },
+        { sourceVolume = "certs", containerPath = "/certs", readOnly = true },
+      ]
+
+      secrets = [
+        { name = "LORE__SERVER__HTTP__PRESIGNED_URL_HMAC_KEY", valueFrom = local.hmac_key_secret_arn },
+      ]
+
+      environment = concat([
+        { name = "LORE_ENV", value = "docker" },
+        { name = "LORE_CONFIG_PATH", value = "/etc/lore/config" },
+        { name = "LORE__SERVER__QUIC__CERTIFICATE__CERT_FILE", value = "/certs/fullchain.crt" },
+        { name = "LORE__SERVER__QUIC__CERTIFICATE__PKEY_FILE", value = "/certs/server.key" },
+        { name = "LORE__SERVER__GRPC__CERTIFICATE__CERT_FILE", value = "/certs/fullchain.crt" },
+        { name = "LORE__SERVER__GRPC__CERTIFICATE__PKEY_FILE", value = "/certs/server.key" },
+        { name = "LORE__SERVER__GRPC__VERIFY_CLIENT_CERTS", value = "false" },
+        { name = "LORE__IMMUTABLE_STORE__MODE", value = "composite" },
+        { name = "LORE__IMMUTABLE_STORE__COMPOSITE__LOCAL__MODE", value = "local" },
+        { name = "LORE__IMMUTABLE_STORE__COMPOSITE__LOCAL__LOCAL__PATH", value = "/srv/urc" },
+        { name = "LORE__IMMUTABLE_STORE__COMPOSITE__LOCAL__LOCAL__MAX_SIZE", value = tostring(local.cache_max_size) },
+        { name = "LORE__IMMUTABLE_STORE__COMPOSITE__LOCAL__LOCAL__FLUSH_DELAY_SECONDS", value = "10" },
+        { name = "LORE__IMMUTABLE_STORE__COMPOSITE__DURABLE__MODE", value = "aws" },
+        { name = "LORE__MUTABLE_STORE__MODE", value = "aws" },
+        { name = "LORE__LOCK_STORE__MODE", value = "aws" },
+        { name = "LORE__PLUGINS__AWS__IMMUTABLE_STORE__S3_BUCKET", value = var.fragment_bucket_name },
+        { name = "LORE__PLUGINS__AWS__IMMUTABLE_STORE__DYNAMODB_FRAGMENTS_TABLE", value = var.fragments_table_name },
+        { name = "LORE__PLUGINS__AWS__IMMUTABLE_STORE__DYNAMODB_METADATA_TABLE", value = var.fragment_metadata_table_name },
+        { name = "LORE__PLUGINS__AWS__MUTABLE_STORE__DYNAMODB_TABLE", value = var.mutable_store_table_name },
+        { name = "LORE__PLUGINS__AWS__LOCK_STORE__DYNAMODB_TABLE", value = var.locks_table_name },
+      ], local.auth_env_vars, local.auth_audience_env, local.replication_env_vars)
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.loreserver.name
+          "awslogs-region"        = data.aws_region.current.name
+          "awslogs-stream-prefix" = "loreserver"
+        }
+      }
+    }],
+
+    # ADOT sidecar (conditional)
+    local.otel_container
+  ))
+
+  tags = var.tags
+}

--- a/modules/unreal/lore/modules/compute/templates/user_data.sh
+++ b/modules/unreal/lore/modules/compute/templates/user_data.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euo pipefail
+
+# =============================================================================
+# NVMe Instance Store Setup for Lore ECS
+# Formats NVMe instance store (if present) and configures ECS agent.
+# Runs before ECS agent starts (cloud-init → multi-user.target ordering).
+# =============================================================================
+
+MOUNT_PATH="${mount_path}"
+ECS_CLUSTER="${cluster_name}"
+CONTAINER_UID="${container_uid}"
+
+# Detect NVMe instance store devices (exclude EBS NVMe volumes)
+# Uses /sys/block model file — more reliable than nvme-cli across AMIs
+INSTANCE_STORE_DEVICES=()
+for device in /dev/nvme*n1; do
+  [ -e "$device" ] || continue
+  devname=$(basename "$device")
+  model=$(cat "/sys/block/$devname/device/model" 2>/dev/null || echo "")
+  if [[ "$model" == *"Instance Storage"* ]]; then
+    INSTANCE_STORE_DEVICES+=("$device")
+  fi
+done
+
+# Format and mount (RAID-0 if multiple devices, single device otherwise)
+if [ $${#INSTANCE_STORE_DEVICES[@]} -gt 1 ]; then
+  dnf install -y mdadm >/dev/null 2>&1 || true
+  mdadm --create /dev/md0 --level=0 --raid-devices=$${#INSTANCE_STORE_DEVICES[@]} \
+    "$${INSTANCE_STORE_DEVICES[@]}" --force
+  mkfs.xfs -f /dev/md0
+  mkdir -p "$MOUNT_PATH"
+  mount -o noatime,nodiratime,discard /dev/md0 "$MOUNT_PATH"
+  RAID_UUID=$(blkid -s UUID -o value /dev/md0)
+  echo "UUID=$RAID_UUID $MOUNT_PATH xfs noatime,nodiratime,discard,nofail 0 2" >> /etc/fstab
+  chown "$CONTAINER_UID:$CONTAINER_UID" "$MOUNT_PATH"
+elif [ $${#INSTANCE_STORE_DEVICES[@]} -eq 1 ]; then
+  mkfs.xfs -f "$${INSTANCE_STORE_DEVICES[0]}"
+  mkdir -p "$MOUNT_PATH"
+  mount -o noatime,nodiratime,discard "$${INSTANCE_STORE_DEVICES[0]}" "$MOUNT_PATH"
+  DEV_UUID=$(blkid -s UUID -o value "$${INSTANCE_STORE_DEVICES[0]}")
+  echo "UUID=$DEV_UUID $MOUNT_PATH xfs noatime,nodiratime,discard,nofail 0 2" >> /etc/fstab
+  chown "$CONTAINER_UID:$CONTAINER_UID" "$MOUNT_PATH"
+else
+  mkdir -p "$MOUNT_PATH"
+  chown "$CONTAINER_UID:$CONTAINER_UID" "$MOUNT_PATH"
+  echo "WARNING: No NVMe instance store found. Using root volume at $MOUNT_PATH"
+fi
+
+# Configure ECS agent
+cat >> /etc/ecs/ecs.config <<EOF
+ECS_CLUSTER=$ECS_CLUSTER
+ECS_ENABLE_TASK_IAM_ROLE=true
+ECS_ENABLE_TASK_ENI=true
+ECS_AVAILABLE_LOGGING_DRIVERS=["json-file","awslogs"]
+EOF

--- a/modules/unreal/lore/modules/compute/variables.tf
+++ b/modules/unreal/lore/modules/compute/variables.tf
@@ -1,0 +1,252 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+}
+
+variable "environment" {
+  description = "Environment name (dev, staging, prod) — used for ASG defaults"
+  type        = string
+}
+
+variable "fragment_bucket_arn" {
+  description = "ARN of the S3 fragment bucket"
+  type        = string
+}
+
+variable "dynamodb_table_arns" {
+  description = "List of DynamoDB table ARNs for IAM policy"
+  type        = list(string)
+}
+
+variable "locks_table_arn" {
+  description = "ARN of the locks DynamoDB table (for GSI access)"
+  type        = string
+}
+
+variable "private_subnet_ids" {
+  description = "Private subnet IDs for ASG instances"
+  type        = list(string)
+}
+
+variable "server_security_group_id" {
+  description = "Security group ID for Lore server instances"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for ECS instances. Unknown types fall back to 28 GiB memory reservation and 937 GB cache size."
+  type        = string
+  default     = "i4i.xlarge"
+}
+
+variable "ami_id" {
+  description = "AMI ID override. If null, uses latest ECS-optimized AL2023."
+  type        = string
+  default     = null
+}
+
+variable "container_user" {
+  description = "User/group for the container process (e.g., '65534', '1000:1000'). Must be numeric UID or UID:GID."
+  type        = string
+  default     = "65534"
+
+  validation {
+    condition     = can(regex("^[0-9]+(:[0-9]+)?$", var.container_user))
+    error_message = "container_user must be a numeric UID (e.g., '65534') or UID:GID (e.g., '1000:1000')."
+  }
+}
+
+variable "asg_min_size" {
+  description = "ASG minimum size. Null = environment-aware default (dev:0, staging:0, prod:1)"
+  type        = number
+  default     = null
+}
+
+variable "asg_max_size" {
+  description = "ASG maximum size. Null = environment-aware default (dev:1, staging:1, prod:3)"
+  type        = number
+  default     = null
+}
+
+variable "asg_desired_size" {
+  description = "ASG desired capacity. Null = environment-aware default (dev:0, staging:1, prod:1)"
+  type        = number
+  default     = null
+}
+
+# =============================================================================
+# ECS Service (Phase 5B)
+# =============================================================================
+
+variable "container_image" {
+  description = "Loreserver container image URI"
+  type        = string
+}
+
+variable "fragment_bucket_name" {
+  description = "S3 fragment bucket name (for LORE__* env vars)"
+  type        = string
+}
+
+variable "fragments_table_name" {
+  description = "DynamoDB fragments table name"
+  type        = string
+}
+
+variable "fragment_metadata_table_name" {
+  description = "DynamoDB fragment metadata table name"
+  type        = string
+}
+
+variable "mutable_store_table_name" {
+  description = "DynamoDB mutable store table name"
+  type        = string
+}
+
+variable "locks_table_name" {
+  description = "DynamoDB locks table name"
+  type        = string
+}
+
+# =============================================================================
+# Phase 6: Security & Observability
+# =============================================================================
+
+variable "tls_certificate_secret_arn" {
+  description = "Secrets Manager ARN for server TLS certificate. If null, a self-signed cert is generated."
+  type        = string
+  default     = null
+}
+
+variable "tls_private_key_secret_arn" {
+  description = "Secrets Manager ARN for server TLS private key. If null, generated with self-signed cert."
+  type        = string
+  default     = null
+}
+
+variable "tls_san_dns_names" {
+  description = "Additional DNS SANs for the self-signed TLS certificate (e.g., custom domain names)"
+  type        = list(string)
+  default     = []
+}
+
+variable "hmac_key_secret_arn" {
+  description = "Secrets Manager ARN for HMAC signing key. If null, a random 32-byte key is generated."
+  type        = string
+  default     = null
+}
+
+variable "write_tier_dns_name" {
+  description = "Cloud Map DNS name (included in self-signed cert SAN)"
+  type        = string
+}
+
+variable "enable_otel_sidecar" {
+  description = "Deploy ADOT sidecar for OpenTelemetry collection (CloudWatch + X-Ray)"
+  type        = bool
+  default     = true
+}
+
+variable "otel_collector_image" {
+  description = "ADOT collector image URI. Override to use a private ECR mirror."
+  type        = string
+  default     = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
+}
+
+variable "auth_mode" {
+  description = "Authentication mode: 'none' (open access), 'cognito' (AWS-native M2M), 'external' (bring your own IdP)"
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "cognito", "external"], var.auth_mode)
+    error_message = "auth_mode must be 'none', 'cognito', or 'external'."
+  }
+}
+
+variable "auth_jwk_endpoint" {
+  description = "JWK endpoint URL (required when auth_mode = 'external')"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.auth_mode != "external" || var.auth_jwk_endpoint != null
+    error_message = "auth_jwk_endpoint is required when auth_mode = 'external'."
+  }
+}
+
+variable "auth_jwt_issuer" {
+  description = "JWT issuer string (required when auth_mode = 'external')"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.auth_mode != "external" || var.auth_jwt_issuer != null
+    error_message = "auth_jwt_issuer is required when auth_mode = 'external'."
+  }
+}
+
+variable "auth_jwt_audience" {
+  description = "JWT audience values the server accepts"
+  type        = list(string)
+  default     = []
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "Lower limit on running tasks during deployment (% of desired_count). Default 66 allows single-task services to deploy without ENI deadlock."
+  type        = number
+  default     = 66
+}
+
+variable "deployment_maximum_percent" {
+  description = "Upper limit on running tasks during deployment (% of desired_count)."
+  type        = number
+  default     = 200
+}
+
+variable "container_memory_reservation" {
+  description = "Soft memory reservation (MiB) for the loreserver container. If null, auto-sizes based on instance type."
+  type        = number
+  default     = null
+}
+
+variable "cache_max_size_bytes" {
+  description = "NVMe cache maximum size in bytes. 0 = auto-size to 80% of instance store capacity."
+  type        = number
+  default     = 0
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log group retention in days. Valid values: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653."
+  type        = number
+  default     = 30
+}
+
+variable "enable_xray_smoke_test" {
+  description = "Deploy X-Ray pipeline smoke test Lambda (validates trace delivery + IAM)"
+  type        = bool
+  default     = true
+}
+
+variable "enable_replication" {
+  description = "Enable the QUIC internal replication endpoint (port 41340). Required for multi-server cache topologies."
+  type        = bool
+  default     = false
+}
+
+variable "replication_peers" {
+  description = "List of peer addresses for fixed topology replication. Each entry is a host:port string (e.g., '10.0.1.50:41340')."
+  type        = list(string)
+  default     = []
+}
+
+variable "service_discovery_registry_arn" {
+  description = "Cloud Map service ARN for ECS service registration. Null when service discovery is disabled."
+  type        = string
+  default     = null
+}

--- a/modules/unreal/lore/modules/compute/versions.tf
+++ b/modules/unreal/lore/modules/compute/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
+  }
+}

--- a/modules/unreal/lore/modules/compute/xray_smoke_test.tf
+++ b/modules/unreal/lore/modules/compute/xray_smoke_test.tf
@@ -1,0 +1,68 @@
+# =============================================================================
+# X-Ray Pipeline Smoke Test Lambda — verifies trace delivery + IAM (when enabled)
+# =============================================================================
+
+data "archive_file" "xray_smoke_test" {
+  count       = var.enable_xray_smoke_test ? 1 : 0
+  type        = "zip"
+  source_file = "${path.module}/lambda/xray_smoke_test.mjs"
+  output_path = "${path.module}/lambda/.build/xray_smoke_test.zip"
+}
+
+resource "aws_lambda_function" "xray_smoke_test" {
+  count            = var.enable_xray_smoke_test ? 1 : 0
+  function_name    = "${var.name_prefix}-xray-smoke-test"
+  handler          = "xray_smoke_test.handler"
+  runtime          = "nodejs20.x"
+  timeout          = 15
+  role             = aws_iam_role.xray_smoke_test[0].arn
+  filename         = data.archive_file.xray_smoke_test[0].output_path
+  source_code_hash = data.archive_file.xray_smoke_test[0].output_base64sha256
+
+  environment {
+    variables = { ENVIRONMENT = var.environment }
+  }
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "xray_smoke_test_assume" {
+  count = var.enable_xray_smoke_test ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "xray_smoke_test" {
+  count              = var.enable_xray_smoke_test ? 1 : 0
+  name_prefix        = "${var.name_prefix}-xray-test-"
+  assume_role_policy = data.aws_iam_policy_document.xray_smoke_test_assume[0].json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "xray_smoke_test_logs" {
+  count      = var.enable_xray_smoke_test ? 1 : 0
+  role       = aws_iam_role.xray_smoke_test[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+# X-Ray actions do NOT support resource-level ARNs. This is an AWS API limitation.
+# See: https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsx-ray.html
+data "aws_iam_policy_document" "xray_smoke_test_xray" {
+  count = var.enable_xray_smoke_test ? 1 : 0
+  statement {
+    actions   = ["xray:PutTraceSegments", "xray:PutTelemetryRecords", "xray:GetTraceSummaries"]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "xray_smoke_test_xray" {
+  count  = var.enable_xray_smoke_test ? 1 : 0
+  name   = "xray-access"
+  role   = aws_iam_role.xray_smoke_test[0].id
+  policy = data.aws_iam_policy_document.xray_smoke_test_xray[0].json
+}

--- a/modules/unreal/lore/modules/edge-pod/README.md
+++ b/modules/unreal/lore/modules/edge-pod/README.md
@@ -1,0 +1,103 @@
+# Edge Pod Sub-Module
+
+Deploys a single Lore edge pod — a self-hydrating read cache that proxies branch resolution
+to the write tier and serves clones from local NVMe.
+
+## Usage
+
+```hcl
+module "edge_pod" {
+  source = "terraform-aws-lore//modules/edge-pod"
+
+  vpc_id                   = module.lore.vpc_id
+  subnet_id                = module.lore.private_subnet_ids[0]
+  server_security_group_id = module.lore.server_security_group_id
+  container_image          = var.container_image
+  write_tier_dns           = module.lore.write_tier_discovery_dns
+  ca_certificate_pem       = module.lore.ca_certificate_pem
+}
+```
+
+## Architecture
+
+- EC2 instance running Docker (not ECS) — independent lifecycle from write tier
+- NVMe instance store formatted as XFS and mounted at `/srv/urc`
+- Self-signed TLS cert generated at boot with instance IP as SAN
+- Composite storage: local NVMe cache + replicated durable backend (QUIC to write tier)
+- Remote mutable store: branch resolution proxied to write tier via gRPC+TLS
+
+## Prerequisites
+
+- Instance type must have instance store (NVMe) — c8gd.8xlarge recommended
+- 32+ vCPU required for full internet egress bandwidth (AWS cap on <32 vCPU instances)
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_instance_profile.edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy_attachment.ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_instance.edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_security_group.edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_vpc_security_group_egress_rule.all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.client_http](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.client_quic_grpc_tcp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.client_quic_grpc_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.write_tier_from_edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.write_tier_from_edge_udp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [random_id.hmac](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [tls_private_key.edge](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_self_signed_cert.edge](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
+| [aws_iam_policy_document.assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ecr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_ssm_parameter.al2023_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssm_parameter) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_ca_certificate_pem"></a> [ca\_certificate\_pem](#input\_ca\_certificate\_pem) | PEM-encoded CA certificate of the write tier (for TLS verification) | `string` | n/a | yes |
+| <a name="input_container_image"></a> [container\_image](#input\_container\_image) | Docker image URI for the Lore server (must match instance architecture) | `string` | n/a | yes |
+| <a name="input_server_security_group_id"></a> [server\_security\_group\_id](#input\_server\_security\_group\_id) | Security group ID of the write tier (edge pod is granted ingress) | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | Subnet ID for the edge pod instance | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID where the edge pod will be deployed | `string` | n/a | yes |
+| <a name="input_write_tier_dns"></a> [write\_tier\_dns](#input\_write\_tier\_dns) | DNS name of the write tier (Cloud Map). Used for both gRPC branch resolution (:41337) and QUIC replication (:41340). | `string` | n/a | yes |
+| <a name="input_allowed_ingress_cidrs"></a> [allowed\_ingress\_cidrs](#input\_allowed\_ingress\_cidrs) | CIDRs allowed to reach the edge pod (QUIC:41337, gRPC:41337, HTTP:41339) | `list(string)` | `[]` | no |
+| <a name="input_hmac_key"></a> [hmac\_key](#input\_hmac\_key) | 64-char hex HMAC key for presigned URLs. Generated if null. | `string` | `null` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | EC2 instance type. c8gd.8xlarge minimum for full bandwidth (32 vCPU exempts internet egress cap). | `string` | `"c8gd.8xlarge"` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for all resources created by this module | `string` | `"edge"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | EC2 instance ID of the edge pod |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | Private IP address of the edge pod |
+| <a name="output_security_group_id"></a> [security\_group\_id](#output\_security\_group\_id) | Security group ID of the edge pod |
+<!-- END_TF_DOCS -->

--- a/modules/unreal/lore/modules/edge-pod/main.tf
+++ b/modules/unreal/lore/modules/edge-pod/main.tf
@@ -1,0 +1,206 @@
+data "aws_region" "current" {}
+
+data "aws_ssm_parameter" "al2023_ami" {
+  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-${local.is_arm64 ? "arm64" : "x86_64"}"
+}
+
+locals {
+  instance_family = split(".", var.instance_type)[0]
+  is_arm64        = contains(["c8gd", "c8g", "c7gd", "c7g", "c7gn", "m7g", "m7gd", "m8g", "r7g", "r7gd", "r8g", "t4g", "im4gn", "is4gen", "x2gd", "hpc7g"], local.instance_family)
+  ecr_registry    = split("/", var.container_image)[0]
+  hmac_key        = var.hmac_key != null ? var.hmac_key : random_id.hmac[0].hex
+}
+
+# =============================================================================
+# HMAC Key (generated when not provided)
+# =============================================================================
+
+resource "random_id" "hmac" {
+  count       = var.hmac_key == null ? 1 : 0
+  byte_length = 32 # 32 bytes = 64 hex characters
+}
+
+# =============================================================================
+# TLS — Self-signed cert (CA:FALSE, IP SAN)
+# =============================================================================
+
+resource "tls_private_key" "edge" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
+}
+
+resource "tls_self_signed_cert" "edge" {
+  private_key_pem = tls_private_key.edge.private_key_pem
+
+  subject {
+    common_name = "${var.name_prefix}-edge-pod"
+  }
+
+  validity_period_hours = 8760 # 1 year
+
+  allowed_uses = [
+    "digital_signature",
+    "key_encipherment",
+    "server_auth",
+  ]
+
+  # IP SAN added after instance creation via userdata (openssl regeneration)
+  # This cert is a fallback — userdata generates the real cert with IP SAN
+}
+
+# =============================================================================
+# Security Group
+# =============================================================================
+
+resource "aws_security_group" "edge" {
+  name_prefix = "${var.name_prefix}-edge-"
+  description = "Edge pod - QUIC/gRPC ingress, write tier egress"
+  vpc_id      = var.vpc_id
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-edge" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_vpc_security_group_ingress_rule" "client_quic_grpc_tcp" {
+  for_each = toset(var.allowed_ingress_cidrs)
+
+  security_group_id = aws_security_group.edge.id
+  description       = "Client gRPC TCP (${each.value})"
+  cidr_ipv4         = each.value
+  from_port         = 41337
+  to_port           = 41337
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "client_quic_grpc_udp" {
+  for_each = toset(var.allowed_ingress_cidrs)
+
+  security_group_id = aws_security_group.edge.id
+  description       = "Client QUIC UDP (${each.value})"
+  cidr_ipv4         = each.value
+  from_port         = 41337
+  to_port           = 41337
+  ip_protocol       = "udp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "client_http" {
+  for_each = toset(var.allowed_ingress_cidrs)
+
+  security_group_id = aws_security_group.edge.id
+  description       = "Client HTTP (${each.value})"
+  cidr_ipv4         = each.value
+  from_port         = 41339
+  to_port           = 41339
+  ip_protocol       = "tcp"
+}
+
+resource "aws_vpc_security_group_egress_rule" "all" {
+  security_group_id = aws_security_group.edge.id
+  description       = "All outbound"
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1"
+}
+
+# Allow edge pod to reach write tier's security group on replication + gRPC ports
+resource "aws_vpc_security_group_ingress_rule" "write_tier_from_edge" {
+  security_group_id            = var.server_security_group_id
+  description                  = "Edge pod replication + gRPC"
+  referenced_security_group_id = aws_security_group.edge.id
+  from_port                    = 41337
+  to_port                      = 41340
+  ip_protocol                  = "tcp"
+}
+
+resource "aws_vpc_security_group_ingress_rule" "write_tier_from_edge_udp" {
+  security_group_id            = var.server_security_group_id
+  description                  = "Edge pod QUIC replication (UDP)"
+  referenced_security_group_id = aws_security_group.edge.id
+  from_port                    = 41340
+  to_port                      = 41340
+  ip_protocol                  = "udp"
+}
+
+# =============================================================================
+# IAM Role + Instance Profile (ECR pull + SSM)
+# =============================================================================
+
+data "aws_iam_policy_document" "assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "edge" {
+  name_prefix        = "${var.name_prefix}-edge-"
+  assume_role_policy = data.aws_iam_policy_document.assume.json
+  tags               = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.edge.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+data "aws_iam_policy_document" "ecr" {
+  statement {
+    actions = [
+      "ecr:GetAuthorizationToken",
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_role_policy" "ecr" {
+  name   = "ecr-pull"
+  role   = aws_iam_role.edge.id
+  policy = data.aws_iam_policy_document.ecr.json
+}
+
+resource "aws_iam_instance_profile" "edge" {
+  name_prefix = "${var.name_prefix}-edge-"
+  role        = aws_iam_role.edge.name
+  tags        = var.tags
+}
+
+# =============================================================================
+# EC2 Instance
+# =============================================================================
+
+resource "aws_instance" "edge" {
+  ami                    = data.aws_ssm_parameter.al2023_ami.value
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  iam_instance_profile   = aws_iam_instance_profile.edge.name
+  vpc_security_group_ids = [aws_security_group.edge.id]
+
+  user_data_base64 = base64encode(templatefile("${path.module}/userdata.sh.tpl", {
+    ecr_region      = data.aws_region.current.name
+    ecr_registry    = local.ecr_registry
+    ca_cert_pem     = var.ca_certificate_pem
+    container_image = var.container_image
+    write_tier_dns  = var.write_tier_dns
+    hmac_key        = local.hmac_key
+  }))
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required" # IMDSv2 only
+  }
+
+  root_block_device {
+    volume_type = "gp3"
+    volume_size = 30
+    encrypted   = true
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-edge-pod" })
+}

--- a/modules/unreal/lore/modules/edge-pod/outputs.tf
+++ b/modules/unreal/lore/modules/edge-pod/outputs.tf
@@ -1,0 +1,14 @@
+output "instance_id" {
+  description = "EC2 instance ID of the edge pod"
+  value       = aws_instance.edge.id
+}
+
+output "private_ip" {
+  description = "Private IP address of the edge pod"
+  value       = aws_instance.edge.private_ip
+}
+
+output "security_group_id" {
+  description = "Security group ID of the edge pod"
+  value       = aws_security_group.edge.id
+}

--- a/modules/unreal/lore/modules/edge-pod/userdata.sh.tpl
+++ b/modules/unreal/lore/modules/edge-pod/userdata.sh.tpl
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+# --- NVMe setup ---
+NVME_DEV=$(lsblk -dpno NAME,MODEL | grep "Instance Storage" | awk '{print $1}' | head -1)
+if [[ -n "$NVME_DEV" ]]; then
+  mkfs.xfs -f "$NVME_DEV"
+  mkdir -p /srv/urc
+  mount "$NVME_DEV" /srv/urc
+  chown 65534:65534 /srv/urc
+fi
+
+# --- Docker + ECR login (retry — NAT gateway may not be ready on first boot) ---
+dnf clean all
+dnf install -y docker
+systemctl enable --now docker
+ECR_OK=0
+for i in $(seq 1 12); do
+  aws ecr get-login-password --region ${ecr_region} | docker login --username AWS --password-stdin ${ecr_registry} && { ECR_OK=1; break; }
+  echo "ECR login attempt $i failed, retrying in 10s..."
+  sleep 10
+done
+[[ $ECR_OK -eq 1 ]] || { echo "FATAL: ECR login failed after 12 attempts"; exit 1; }
+
+# --- Write tier CA cert ---
+mkdir -p /opt/edge/certs
+cat > /opt/edge/certs/write-tier-ca.pem <<'CACERT'
+${ca_cert_pem}
+CACERT
+
+# --- Self-signed cert with IP SAN (CA:FALSE) ---
+INSTANCE_IP=$(TOKEN=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60") && \
+  curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/local-ipv4)
+[[ -n "$INSTANCE_IP" ]] || { echo "FATAL: Could not retrieve instance IP from IMDS"; exit 1; }
+
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 \
+  -keyout /opt/edge/certs/server.key -out /opt/edge/certs/server.crt \
+  -days 365 -nodes -subj "/CN=edge-pod" \
+  -addext "subjectAltName=IP:$INSTANCE_IP" \
+  -addext "basicConstraints=critical,CA:FALSE"
+
+cat /opt/edge/certs/server.crt > /opt/edge/certs/fullchain.crt
+
+# --- Combined CA bundle ---
+cat /etc/pki/tls/certs/ca-bundle.crt /opt/edge/certs/write-tier-ca.pem > /opt/edge/certs/combined-ca.pem
+
+# --- Run edge pod ---
+docker run -d --name edge-pod \
+  --restart unless-stopped \
+  --network host \
+  -v /srv/urc:/srv/urc \
+  -v /opt/edge/certs:/certs:ro \
+  -e LORE_ENV=docker \
+  -e SSL_CERT_FILE=/certs/combined-ca.pem \
+  -e LORE__SERVER__HTTP__PRESIGNED_URL_HMAC_KEY=${hmac_key} \
+  -e LORE__SERVER__QUIC__CERTIFICATE__CERT_FILE=/certs/fullchain.crt \
+  -e LORE__SERVER__QUIC__CERTIFICATE__PKEY_FILE=/certs/server.key \
+  -e LORE__SERVER__GRPC__CERTIFICATE__CERT_FILE=/certs/fullchain.crt \
+  -e LORE__SERVER__GRPC__CERTIFICATE__PKEY_FILE=/certs/server.key \
+  -e LORE__SERVER__GRPC__VERIFY_CLIENT_CERTS=false \
+  -e LORE__IMMUTABLE_STORE__MODE=composite \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__LOCAL__MODE=local \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__LOCAL__LOCAL__PATH=/srv/urc \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__LOCAL__LOCAL__MAX_SIZE=800000000000 \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__LOCAL__LOCAL__FLUSH_DELAY_SECONDS=10 \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__DURABLE__MODE=replicated \
+  -e "LORE__IMMUTABLE_STORE__COMPOSITE__DURABLE__REPLICATED__REMOTE_URL=lore://${write_tier_dns}:41340" \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__DURABLE__REPLICATED__REGENERATE_RETRY__INITIAL_BACKOFF_MS=100 \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__DURABLE__REPLICATED__REGENERATE_RETRY__MAX_BACKOFF_MS=1000 \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__DURABLE__REPLICATED__REGENERATE_RETRY__MAX_ATTEMPTS=10 \
+  -e LORE__IMMUTABLE_STORE__COMPOSITE__DURABLE__REPLICATED__PERIODIC_CLIENT_REFRESH_SECS=180 \
+  -e LORE__MUTABLE_STORE__MODE=remote \
+  -e "LORE__MUTABLE_STORE__REMOTE__REMOTE_URL=lores://${write_tier_dns}:41337" \
+  -e LORE__LOCK_STORE__MODE=local \
+  ${container_image}

--- a/modules/unreal/lore/modules/edge-pod/variables.tf
+++ b/modules/unreal/lore/modules/edge-pod/variables.tf
@@ -1,0 +1,77 @@
+# =============================================================================
+# Required
+# =============================================================================
+
+variable "vpc_id" {
+  description = "VPC ID where the edge pod will be deployed"
+  type        = string
+  nullable    = false
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for the edge pod instance"
+  type        = string
+  nullable    = false
+}
+
+variable "server_security_group_id" {
+  description = "Security group ID of the write tier (edge pod is granted ingress)"
+  type        = string
+  nullable    = false
+}
+
+variable "container_image" {
+  description = "Docker image URI for the Lore server (must match instance architecture)"
+  type        = string
+  nullable    = false
+}
+
+variable "write_tier_dns" {
+  description = "DNS name of the write tier (Cloud Map). Used for both gRPC branch resolution (:41337) and QUIC replication (:41340)."
+  type        = string
+  nullable    = false
+}
+
+variable "ca_certificate_pem" {
+  description = "PEM-encoded CA certificate of the write tier (for TLS verification)"
+  type        = string
+  nullable    = false
+  sensitive   = true
+}
+
+# =============================================================================
+# Optional
+# =============================================================================
+
+variable "instance_type" {
+  description = "EC2 instance type. c8gd.8xlarge minimum for full bandwidth (32 vCPU exempts internet egress cap)."
+  type        = string
+  default     = "c8gd.8xlarge"
+  nullable    = false
+}
+
+variable "name_prefix" {
+  description = "Name prefix for all resources created by this module"
+  type        = string
+  default     = "edge"
+  nullable    = false
+}
+
+variable "hmac_key" {
+  description = "64-char hex HMAC key for presigned URLs. Generated if null."
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "allowed_ingress_cidrs" {
+  description = "CIDRs allowed to reach the edge pod (QUIC:41337, gRPC:41337, HTTP:41339)"
+  type        = list(string)
+  default     = []
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}

--- a/modules/unreal/lore/modules/edge-pod/versions.tf
+++ b/modules/unreal/lore/modules/edge-pod/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}

--- a/modules/unreal/lore/modules/storage/README.md
+++ b/modules/unreal/lore/modules/storage/README.md
@@ -1,0 +1,65 @@
+# Storage Sub-Module
+
+Provisions S3 bucket (fragments) and 4 DynamoDB tables (fragments, fragment-metadata, mutable-typed-store, locks).
+
+This is an internal sub-module of `terraform-aws-lore`. Do not consume directly — use the root module.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_dynamodb_table.fragment_metadata](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.fragments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.locks](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_dynamodb_table.mutable_store](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
+| [aws_s3_bucket.fragments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
+| [aws_s3_bucket_intelligent_tiering_configuration.fragments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_intelligent_tiering_configuration) | resource |
+| [aws_s3_bucket_lifecycle_configuration.fragments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_lifecycle_configuration) | resource |
+| [aws_s3_bucket_public_access_block.fragments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_server_side_encryption_configuration.fragments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
+| [aws_s3_bucket_versioning.fragments](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix for all resource names | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | n/a | yes |
+| <a name="input_enable_deletion_protection"></a> [enable\_deletion\_protection](#input\_enable\_deletion\_protection) | Enable deletion protection on DynamoDB tables | `bool` | `true` | no |
+| <a name="input_enable_force_destroy"></a> [enable\_force\_destroy](#input\_enable\_force\_destroy) | Allow S3 bucket deletion when non-empty | `bool` | `false` | no |
+| <a name="input_intelligent_tiering_archive_days"></a> [intelligent\_tiering\_archive\_days](#input\_intelligent\_tiering\_archive\_days) | Days before fragments move to Archive Access tier. 0 disables Intelligent-Tiering. | `number` | `90` | no |
+| <a name="input_intelligent_tiering_deep_archive_days"></a> [intelligent\_tiering\_deep\_archive\_days](#input\_intelligent\_tiering\_deep\_archive\_days) | Days before fragments move to Deep Archive Access tier. | `number` | `180` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_fragment_bucket_arn"></a> [fragment\_bucket\_arn](#output\_fragment\_bucket\_arn) | S3 bucket ARN |
+| <a name="output_fragment_bucket_name"></a> [fragment\_bucket\_name](#output\_fragment\_bucket\_name) | S3 bucket name |
+| <a name="output_fragment_metadata_table_arn"></a> [fragment\_metadata\_table\_arn](#output\_fragment\_metadata\_table\_arn) | DynamoDB fragment metadata table ARN |
+| <a name="output_fragment_metadata_table_name"></a> [fragment\_metadata\_table\_name](#output\_fragment\_metadata\_table\_name) | DynamoDB fragment metadata table name |
+| <a name="output_fragments_table_arn"></a> [fragments\_table\_arn](#output\_fragments\_table\_arn) | DynamoDB fragments table ARN |
+| <a name="output_fragments_table_name"></a> [fragments\_table\_name](#output\_fragments\_table\_name) | DynamoDB fragments table name |
+| <a name="output_locks_table_arn"></a> [locks\_table\_arn](#output\_locks\_table\_arn) | DynamoDB locks table ARN |
+| <a name="output_locks_table_name"></a> [locks\_table\_name](#output\_locks\_table\_name) | DynamoDB locks table name |
+| <a name="output_mutable_store_table_arn"></a> [mutable\_store\_table\_arn](#output\_mutable\_store\_table\_arn) | DynamoDB mutable store table ARN |
+| <a name="output_mutable_store_table_name"></a> [mutable\_store\_table\_name](#output\_mutable\_store\_table\_name) | DynamoDB mutable store table name |
+<!-- END_TF_DOCS -->

--- a/modules/unreal/lore/modules/storage/dynamodb.tf
+++ b/modules/unreal/lore/modules/storage/dynamodb.tf
@@ -1,0 +1,119 @@
+# =============================================================================
+# DynamoDB — Metadata, branches, locks
+# =============================================================================
+
+resource "aws_dynamodb_table" "fragments" {
+  name         = "${var.name_prefix}-fragments"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "hash"
+  range_key    = "repository_context"
+
+  attribute {
+    name = "hash"
+    type = "B"
+  }
+  attribute {
+    name = "repository_context"
+    type = "B"
+  }
+
+  point_in_time_recovery { enabled = true }
+  deletion_protection_enabled = var.enable_deletion_protection
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-fragments" })
+}
+
+resource "aws_dynamodb_table" "fragment_metadata" {
+  name         = "${var.name_prefix}-fragment-metadata"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "hash"
+
+  attribute {
+    name = "hash"
+    type = "B"
+  }
+
+  point_in_time_recovery { enabled = true }
+  deletion_protection_enabled = var.enable_deletion_protection
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-fragment-metadata" })
+}
+
+resource "aws_dynamodb_table" "mutable_store" {
+  name         = "${var.name_prefix}-mutable-typed-store"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "repository_id"
+  range_key    = "key"
+
+  attribute {
+    name = "repository_id"
+    type = "B"
+  }
+  attribute {
+    name = "key"
+    type = "B"
+  }
+
+  point_in_time_recovery { enabled = true }
+  deletion_protection_enabled = var.enable_deletion_protection
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-mutable-typed-store" })
+}
+
+resource "aws_dynamodb_table" "locks" {
+  name         = "${var.name_prefix}-locks"
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "hash"
+  range_key    = "repositoryBranch"
+
+  attribute {
+    name = "hash"
+    type = "B"
+  }
+  attribute {
+    name = "repositoryBranch"
+    type = "B"
+  }
+  attribute {
+    name = "ownerId"
+    type = "S"
+  }
+  attribute {
+    name = "repository"
+    type = "B"
+  }
+  attribute {
+    name = "branch"
+    type = "B"
+  }
+  attribute {
+    name = "description"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "owner-repo-branch"
+    hash_key        = "ownerId"
+    range_key       = "repositoryBranch"
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name            = "repo-branch"
+    hash_key        = "repository"
+    range_key       = "branch"
+    projection_type = "ALL"
+  }
+
+  global_secondary_index {
+    name            = "repo-branch-description"
+    hash_key        = "repositoryBranch"
+    range_key       = "description"
+    projection_type = "ALL"
+  }
+
+  point_in_time_recovery { enabled = true }
+  deletion_protection_enabled = var.enable_deletion_protection
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-locks" })
+}

--- a/modules/unreal/lore/modules/storage/outputs.tf
+++ b/modules/unreal/lore/modules/storage/outputs.tf
@@ -1,0 +1,49 @@
+output "fragment_bucket_name" {
+  description = "S3 bucket name"
+  value       = aws_s3_bucket.fragments.id
+}
+
+output "fragment_bucket_arn" {
+  description = "S3 bucket ARN"
+  value       = aws_s3_bucket.fragments.arn
+}
+
+output "fragments_table_name" {
+  description = "DynamoDB fragments table name"
+  value       = aws_dynamodb_table.fragments.name
+}
+
+output "fragments_table_arn" {
+  description = "DynamoDB fragments table ARN"
+  value       = aws_dynamodb_table.fragments.arn
+}
+
+output "fragment_metadata_table_name" {
+  description = "DynamoDB fragment metadata table name"
+  value       = aws_dynamodb_table.fragment_metadata.name
+}
+
+output "fragment_metadata_table_arn" {
+  description = "DynamoDB fragment metadata table ARN"
+  value       = aws_dynamodb_table.fragment_metadata.arn
+}
+
+output "mutable_store_table_name" {
+  description = "DynamoDB mutable store table name"
+  value       = aws_dynamodb_table.mutable_store.name
+}
+
+output "mutable_store_table_arn" {
+  description = "DynamoDB mutable store table ARN"
+  value       = aws_dynamodb_table.mutable_store.arn
+}
+
+output "locks_table_name" {
+  description = "DynamoDB locks table name"
+  value       = aws_dynamodb_table.locks.name
+}
+
+output "locks_table_arn" {
+  description = "DynamoDB locks table ARN"
+  value       = aws_dynamodb_table.locks.arn
+}

--- a/modules/unreal/lore/modules/storage/s3.tf
+++ b/modules/unreal/lore/modules/storage/s3.tf
@@ -1,0 +1,63 @@
+# =============================================================================
+# S3 — Durable fragment storage
+# =============================================================================
+
+resource "aws_s3_bucket" "fragments" {
+  bucket_prefix = "${var.name_prefix}-fragments-"
+  force_destroy = var.enable_force_destroy
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-fragments" })
+}
+
+resource "aws_s3_bucket_versioning" "fragments" {
+  bucket = aws_s3_bucket.fragments.id
+  versioning_configuration { status = "Disabled" }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "fragments" {
+  bucket = aws_s3_bucket.fragments.id
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "fragments" {
+  bucket                  = aws_s3_bucket.fragments.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_intelligent_tiering_configuration" "fragments" {
+  count  = var.intelligent_tiering_archive_days > 0 ? 1 : 0
+  bucket = aws_s3_bucket.fragments.id
+  name   = "fragment-tiering"
+
+  tiering {
+    access_tier = "ARCHIVE_ACCESS"
+    days        = var.intelligent_tiering_archive_days
+  }
+
+  dynamic "tiering" {
+    for_each = var.intelligent_tiering_deep_archive_days > var.intelligent_tiering_archive_days ? [1] : []
+    content {
+      access_tier = "DEEP_ARCHIVE_ACCESS"
+      days        = var.intelligent_tiering_deep_archive_days
+    }
+  }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "fragments" {
+  bucket = aws_s3_bucket.fragments.id
+
+  rule {
+    id     = "abort-incomplete-multipart"
+    status = "Enabled"
+    filter {}
+
+    abort_incomplete_multipart_upload { days_after_initiation = 7 }
+  }
+}

--- a/modules/unreal/lore/modules/storage/variables.tf
+++ b/modules/unreal/lore/modules/storage/variables.tf
@@ -1,0 +1,41 @@
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = length(var.name_prefix) >= 3 && length(var.name_prefix) <= 24
+    error_message = "name_prefix must be 3-24 characters (S3 bucket prefix + random suffix must fit 63-char limit)."
+  }
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+}
+
+variable "enable_force_destroy" {
+  description = "Allow S3 bucket deletion when non-empty"
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "enable_deletion_protection" {
+  description = "Enable deletion protection on DynamoDB tables"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "intelligent_tiering_archive_days" {
+  description = "Days before fragments move to Archive Access tier. 0 disables Intelligent-Tiering."
+  type        = number
+  default     = 90
+}
+
+variable "intelligent_tiering_deep_archive_days" {
+  description = "Days before fragments move to Deep Archive Access tier."
+  type        = number
+  default     = 180
+}

--- a/modules/unreal/lore/modules/storage/versions.tf
+++ b/modules/unreal/lore/modules/storage/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/unreal/lore/modules/vpc/README.md
+++ b/modules/unreal/lore/modules/vpc/README.md
@@ -1,0 +1,65 @@
+# VPC Sub-Module
+
+Provisions VPC, public/private subnets, IGW, NAT gateway, and route tables.
+
+This is an internal sub-module of `terraform-aws-lore`. Do not consume directly — use the root module.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_log_group.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_default_security_group.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/default_security_group) | resource |
+| [aws_eip.nat](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) | resource |
+| [aws_flow_log.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log) | resource |
+| [aws_iam_role.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.flow_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_internet_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/internet_gateway) | resource |
+| [aws_nat_gateway.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/nat_gateway) | resource |
+| [aws_route_table.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table) | resource |
+| [aws_route_table_association.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_route_table_association.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route_table_association) | resource |
+| [aws_subnet.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_subnet.public](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/subnet) | resource |
+| [aws_vpc.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | List of availability zones (minimum 2) | `list(string)` | n/a | yes |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Name prefix for all VPC resources | `string` | n/a | yes |
+| <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR block for the VPC | `string` | n/a | yes |
+| <a name="input_enable_flow_logs"></a> [enable\_flow\_logs](#input\_enable\_flow\_logs) | Enable VPC flow logs to CloudWatch | `bool` | `false` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_nat_gateway_id"></a> [nat\_gateway\_id](#output\_nat\_gateway\_id) | ID of the NAT gateway |
+| <a name="output_private_route_table_id"></a> [private\_route\_table\_id](#output\_private\_route\_table\_id) | ID of the private route table |
+| <a name="output_private_subnet_ids"></a> [private\_subnet\_ids](#output\_private\_subnet\_ids) | IDs of the private subnets |
+| <a name="output_public_route_table_id"></a> [public\_route\_table\_id](#output\_public\_route\_table\_id) | ID of the public route table |
+| <a name="output_public_subnet_ids"></a> [public\_subnet\_ids](#output\_public\_subnet\_ids) | IDs of the public subnets |
+| <a name="output_vpc_id"></a> [vpc\_id](#output\_vpc\_id) | ID of the VPC |
+<!-- END_TF_DOCS -->

--- a/modules/unreal/lore/modules/vpc/main.tf
+++ b/modules/unreal/lore/modules/vpc/main.tf
@@ -1,0 +1,145 @@
+resource "aws_vpc" "this" {
+  cidr_block           = var.vpc_cidr
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-vpc" })
+}
+
+# Restrict default SG to deny all traffic (CIS 5.4)
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.this.id
+  tags   = merge(var.tags, { Name = "${var.name_prefix}-default-sg-restricted" })
+}
+
+resource "aws_internet_gateway" "this" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-igw" })
+}
+
+resource "aws_subnet" "public" {
+  count                   = length(var.availability_zones)
+  vpc_id                  = aws_vpc.this.id
+  cidr_block              = cidrsubnet(var.vpc_cidr, 8, count.index)
+  availability_zone       = var.availability_zones[count.index]
+  map_public_ip_on_launch = false
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-public-${count.index + 1}" })
+}
+
+resource "aws_subnet" "private" {
+  count             = length(var.availability_zones)
+  vpc_id            = aws_vpc.this.id
+  cidr_block        = cidrsubnet(var.vpc_cidr, 8, count.index + length(var.availability_zones))
+  availability_zone = var.availability_zones[count.index]
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-private-${count.index + 1}" })
+}
+
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-nat-eip" })
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = aws_subnet.public[0].id
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-nat" })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.this.id
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-public-rt" })
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = aws_nat_gateway.this.id
+  }
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-private-rt" })
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.availability_zones)
+  subnet_id      = aws_subnet.public[count.index].id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.availability_zones)
+  subnet_id      = aws_subnet.private[count.index].id
+  route_table_id = aws_route_table.private.id
+}
+
+# =============================================================================
+# VPC Flow Logs (optional)
+# =============================================================================
+
+resource "aws_cloudwatch_log_group" "flow_logs" {
+  count             = var.enable_flow_logs ? 1 : 0
+  name              = "/vpc/${var.name_prefix}-flow-logs"
+  retention_in_days = 30
+  tags              = var.tags
+}
+
+resource "aws_iam_role" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+  name  = "${var.name_prefix}-vpc-flow-logs"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Service = "vpc-flow-logs.amazonaws.com" }
+      Action    = "sts:AssumeRole"
+    }]
+  })
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy" "flow_logs" {
+  count = var.enable_flow_logs ? 1 : 0
+  name  = "flow-logs"
+  role  = aws_iam_role.flow_logs[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = [
+        "logs:CreateLogStream",
+        "logs:PutLogEvents",
+        "logs:DescribeLogGroups",
+        "logs:DescribeLogStreams"
+      ]
+      Resource = "${aws_cloudwatch_log_group.flow_logs[0].arn}:*"
+    }]
+  })
+}
+
+resource "aws_flow_log" "this" {
+  count                = var.enable_flow_logs ? 1 : 0
+  vpc_id               = aws_vpc.this.id
+  traffic_type         = "ALL"
+  iam_role_arn         = aws_iam_role.flow_logs[0].arn
+  log_destination      = aws_cloudwatch_log_group.flow_logs[0].arn
+  log_destination_type = "cloud-watch-logs"
+
+  tags = merge(var.tags, { Name = "${var.name_prefix}-flow-log" })
+}

--- a/modules/unreal/lore/modules/vpc/outputs.tf
+++ b/modules/unreal/lore/modules/vpc/outputs.tf
@@ -1,0 +1,29 @@
+output "vpc_id" {
+  description = "ID of the VPC"
+  value       = aws_vpc.this.id
+}
+
+output "public_subnet_ids" {
+  description = "IDs of the public subnets"
+  value       = aws_subnet.public[*].id
+}
+
+output "private_subnet_ids" {
+  description = "IDs of the private subnets"
+  value       = aws_subnet.private[*].id
+}
+
+output "public_route_table_id" {
+  description = "ID of the public route table"
+  value       = aws_route_table.public.id
+}
+
+output "private_route_table_id" {
+  description = "ID of the private route table"
+  value       = aws_route_table.private.id
+}
+
+output "nat_gateway_id" {
+  description = "ID of the NAT gateway"
+  value       = aws_nat_gateway.this.id
+}

--- a/modules/unreal/lore/modules/vpc/variables.tf
+++ b/modules/unreal/lore/modules/vpc/variables.tf
@@ -1,0 +1,39 @@
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = can(cidrhost(var.vpc_cidr, 0))
+    error_message = "vpc_cidr must be a valid CIDR block (e.g., 10.0.0.0/16)."
+  }
+}
+
+variable "name_prefix" {
+  description = "Name prefix for all VPC resources"
+  type        = string
+  nullable    = false
+}
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "availability_zones" {
+  description = "List of availability zones (minimum 2)"
+  type        = list(string)
+  nullable    = false
+
+  validation {
+    condition     = length(var.availability_zones) >= 2
+    error_message = "At least 2 availability zones are required."
+  }
+}
+
+variable "enable_flow_logs" {
+  description = "Enable VPC flow logs to CloudWatch"
+  type        = bool
+  default     = false
+}

--- a/modules/unreal/lore/modules/vpc/versions.tf
+++ b/modules/unreal/lore/modules/vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/modules/unreal/lore/outputs.tf
+++ b/modules/unreal/lore/outputs.tf
@@ -1,0 +1,124 @@
+# =============================================================================
+# Connection (what clients need)
+# =============================================================================
+
+output "ca_certificate_pem" {
+  description = "CA certificate PEM — add to client SSL_CERT_FILE bundle for TLS trust"
+  value       = module.compute.tls_ca_cert_pem
+}
+
+# =============================================================================
+# Edge Pod Wiring (pass these to modules/edge-pod)
+# =============================================================================
+
+output "vpc_id" {
+  description = "VPC ID for placing edge pods"
+  value       = local.vpc_id
+}
+
+output "private_subnet_ids" {
+  description = "Private subnet IDs for placing edge pods"
+  value       = local.private_subnet_ids
+}
+
+output "server_security_group_id" {
+  description = "Security group ID — edge pods need ingress to this group"
+  value       = aws_security_group.server.id
+}
+
+output "write_tier_discovery_dns" {
+  description = "Cloud Map DNS for edge pod → write tier (gRPC:41337 + QUIC:41340)"
+  value       = "write-tier.${local.name_prefix}.internal"
+}
+
+# =============================================================================
+# Auth (when auth_mode = "cognito")
+# =============================================================================
+
+output "cognito_user_pool_id" {
+  description = "Cognito User Pool ID (null when auth_mode != 'cognito')"
+  value       = try(module.auth[0].user_pool_id, null)
+}
+
+output "cognito_client_id" {
+  description = "Cognito app client ID (null when auth_mode != 'cognito')"
+  value       = try(module.auth[0].client_id, null)
+}
+
+output "cognito_client_secret" {
+  description = "Cognito app client secret (null when auth_mode != 'cognito')"
+  value       = try(module.auth[0].client_secret, null)
+  sensitive   = true
+}
+
+output "cognito_token_endpoint" {
+  description = "Cognito OAuth2 token endpoint (null when auth_mode != 'cognito')"
+  value       = try(module.auth[0].token_endpoint, null)
+}
+
+# =============================================================================
+# Infrastructure (advanced integration, debugging, cross-module wiring)
+# =============================================================================
+
+output "public_subnet_ids" {
+  description = "Public subnet IDs"
+  value       = local.public_subnet_ids
+}
+
+output "fragment_bucket_name" {
+  description = "S3 bucket name for fragment storage"
+  value       = module.data.fragment_bucket_name
+}
+
+output "fragment_bucket_arn" {
+  description = "S3 bucket ARN for fragment storage"
+  value       = module.data.fragment_bucket_arn
+}
+
+output "dynamodb_table_arns" {
+  description = "Map of DynamoDB table ARNs"
+  value = {
+    fragments         = module.data.fragments_table_arn
+    fragment_metadata = module.data.fragment_metadata_table_arn
+    mutable_store     = module.data.mutable_store_table_arn
+    locks             = module.data.locks_table_arn
+  }
+}
+
+output "task_role_arn" {
+  description = "ECS task IAM role ARN"
+  value       = module.compute.task_role_arn
+}
+
+output "execution_role_arn" {
+  description = "ECS execution IAM role ARN"
+  value       = module.compute.execution_role_arn
+}
+
+output "ecs_cluster_name" {
+  description = "ECS cluster name"
+  value       = module.compute.ecs_cluster_name
+}
+
+output "ecs_cluster_arn" {
+  description = "ECS cluster ARN"
+  value       = module.compute.ecs_cluster_arn
+}
+
+output "cloud_map_namespace_id" {
+  description = "Cloud Map namespace ID for edge pod service discovery"
+  value       = aws_service_discovery_private_dns_namespace.lore.id
+}
+
+output "effective_config" {
+  description = "Resolved configuration after environment-aware defaults"
+  value = {
+    name_prefix                = local.name_prefix
+    environment                = var.environment
+    instance_type              = var.instance_type
+    asg                        = module.compute.effective_asg_config
+    auth_mode                  = var.auth_mode
+    enable_otel_sidecar        = var.enable_otel_sidecar
+    enable_deletion_protection = var.enable_deletion_protection
+  }
+}

--- a/modules/unreal/lore/scripts/build-ca-bundle.sh
+++ b/modules/unreal/lore/scripts/build-ca-bundle.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/build-ca-bundle.sh — Export CA cert from Terraform and build combined trust bundle.
+# Usage: ./scripts/build-ca-bundle.sh [terraform-dir] [output-path]
+#
+# Sets SSL_CERT_FILE for lores:// (QUIC+TLS) connections.
+# The bundle REPLACES the system trust store (rustls-native-certs behavior),
+# Requires: bash 4+, terraform CLI
+# Platforms: Linux, macOS, WSL2
+# so it must include both system certs AND the Lore CA.
+set -euo pipefail
+
+TF_DIR="${1:-$(dirname "$0")/../examples/minimal}"
+OUTPUT="${2:-/tmp/lore-combined-ca.pem}"
+
+echo "=== Building CA bundle ==="
+echo "  Terraform dir: $TF_DIR"
+echo "  Output:        $OUTPUT"
+echo ""
+
+# Extract CA cert from Terraform state
+cd "$TF_DIR"
+CA_PEM=$(terraform state show 'module.lore.module.compute.tls_self_signed_cert.ca[0]' 2>/dev/null \
+  | sed -n '/cert_pem.*<<-EOT/,/EOT/{ /cert_pem/d; /EOT/d; s/^[[:space:]]*//; p }')
+
+if [[ -z "$CA_PEM" ]]; then
+  # Fallback: try terraform output (works regardless of resource naming)
+  CA_PEM=$(terraform output -raw ca_certificate_pem 2>/dev/null || true)
+fi
+
+if [[ -z "$CA_PEM" ]]; then
+  echo "ERROR: Could not extract CA cert from Terraform state." >&2
+  echo "  Is infrastructure deployed? Run 'terraform apply' first." >&2
+  exit 1
+fi
+
+# Find system CA bundle
+if [[ -f /etc/pki/tls/certs/ca-bundle.crt ]]; then
+  SYSTEM_CA=/etc/pki/tls/certs/ca-bundle.crt
+elif [[ -f /etc/ssl/certs/ca-certificates.crt ]]; then
+  SYSTEM_CA=/etc/ssl/certs/ca-certificates.crt
+else
+  echo "ERROR: System CA bundle not found" >&2
+  exit 1
+fi
+
+# Build combined bundle
+cat "$SYSTEM_CA" > "$OUTPUT"
+echo "$CA_PEM" >> "$OUTPUT"
+
+LINES=$(wc -l < "$OUTPUT")
+echo "  ✓ Combined bundle: $OUTPUT ($LINES lines)"
+echo ""
+echo "To use:"
+echo "  export SSL_CERT_FILE=$OUTPUT"
+echo ""
+echo "Then connect with lores:// scheme:"
+echo "  lore repository list lores://<nlb-dns>:41337/"

--- a/modules/unreal/lore/scripts/get-task-ip.sh
+++ b/modules/unreal/lore/scripts/get-task-ip.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# scripts/get-task-ip.sh — Get the private IP of the running Lore ECS task.
+# Requires: bash 4+, aws CLI
+# Platforms: Linux, macOS, WSL2
+# Usage: ./scripts/get-task-ip.sh [cluster] [service] [region]
+set -euo pipefail
+
+CLUSTER="${1:-lore-dev-cluster}"
+SERVICE="${2:-lore-dev-loreserver}"
+REGION="${3:-us-west-2}"
+
+TASK_ARN=$(aws ecs list-tasks --cluster "$CLUSTER" --service-name "$SERVICE" \
+  --desired-status RUNNING --query 'taskArns[0]' --output text --region "$REGION")
+
+if [[ "$TASK_ARN" == "None" || -z "$TASK_ARN" ]]; then
+  echo "ERROR: No running tasks in $CLUSTER/$SERVICE" >&2
+  exit 1
+fi
+
+IP=$(aws ecs describe-tasks --cluster "$CLUSTER" --tasks "$TASK_ARN" --region "$REGION" \
+  --query 'tasks[0].attachments[0].details[?name==`privateIPv4Address`].value|[0]' --output text)
+
+echo "$CLUSTER/$SERVICE → $IP" >&2
+echo "$IP"

--- a/modules/unreal/lore/scripts/test-connectivity.sh
+++ b/modules/unreal/lore/scripts/test-connectivity.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# scripts/test-connectivity.sh — Verify client connectivity to a Lore deployment.
+# Requires: bash 4+, aws CLI, lore binary
+# Platforms: Linux, macOS, WSL2
+# Usage: ./scripts/test-connectivity.sh <lore-binary> [host:port]
+set -euo pipefail
+
+LORE="${1:?Usage: $0 <lore-binary> [host:port]}"
+TARGET="${2:-127.0.0.1:41337}"
+HOST="${TARGET%%:*}"
+PORT="${TARGET##*:}"
+
+echo "=== Lore Connectivity Test ==="
+echo "  Target: $TARGET"
+echo "  Binary: $LORE"
+echo ""
+
+# 1. Binary check
+echo "--- Binary ---"
+if "$LORE" --version 2>/dev/null; then
+  echo "  ✓ Binary OK"
+else
+  echo "  ✗ Binary not found or not executable" >&2
+  exit 1
+fi
+echo ""
+
+# 2. TCP connectivity (gRPC)
+echo "--- TCP :$PORT (gRPC) ---"
+if timeout 3 bash -c "echo >/dev/tcp/$HOST/$PORT" 2>/dev/null; then
+  echo "  ✓ TCP OPEN"
+else
+  echo "  ✗ TCP CLOSED — check tunnel, firewall, or security group"
+  echo "    Hint: If using SSM tunnel, run scripts/ssm-tunnel.sh first"
+fi
+echo ""
+
+# 3. gRPC operation
+echo "--- gRPC list repos ---"
+if OUTPUT=$(timeout 10 "$LORE" repository list "grpc://$TARGET/" 2>&1); then
+  REPO_COUNT=$(echo "$OUTPUT" | wc -l)
+  echo "  ✓ gRPC works ($REPO_COUNT repos found)"
+else
+  RC=$?
+  if [ $RC -eq 124 ]; then
+    echo "  ✗ gRPC TIMEOUT (10s) — server may be unresponsive or tunnel stale"
+  else
+    # Extract the actionable error (first meaningful phrase after "Error")
+    SHORT_ERR=$(echo "$OUTPUT" | grep -o 'Connection refused\|tls handshake\|connection reset\|permission denied\|authorization' | head -1)
+    echo "  ✗ gRPC failed: ${SHORT_ERR:-unknown error}"
+    echo "    Full error: $(echo "$OUTPUT" | head -1 | cut -c1-120)"
+  fi
+fi
+echo ""
+
+# 4. TLS bundle check
+echo "--- TLS bundle ---"
+if [[ -n "${SSL_CERT_FILE:-}" ]]; then
+  if [[ -f "$SSL_CERT_FILE" ]]; then
+    LINES=$(wc -l < "$SSL_CERT_FILE")
+    echo "  ✓ SSL_CERT_FILE=$SSL_CERT_FILE ($LINES lines)"
+  else
+    echo "  ✗ SSL_CERT_FILE set but file not found: $SSL_CERT_FILE"
+  fi
+else
+  echo "  ⚠ SSL_CERT_FILE not set — lores:// will fail TLS validation"
+  echo "    Hint: Run scripts/build-ca-bundle.sh to create the bundle"
+fi
+echo ""
+
+# 5. QUIC (only works with direct UDP connectivity, not over SSM tunnel)
+echo "--- QUIC (lore://) ---"
+if [[ "$HOST" == "127.0.0.1" || "$HOST" == "localhost" ]]; then
+  echo "  ⚠ Skipped — QUIC (UDP) cannot traverse SSM port forward (TCP-only)"
+  echo "    To test QUIC, run from within the VPC via SSM send-command"
+else
+  if OUTPUT=$(timeout 10 "$LORE" repository list "lore://$TARGET/" 2>&1); then
+    echo "  ✓ QUIC works"
+  else
+    RC=$?
+    if [ $RC -eq 124 ]; then
+      echo "  ✗ QUIC TIMEOUT (10s) — UDP may be blocked or server unresponsive"
+    else
+      echo "  ✗ QUIC failed: $(echo "$OUTPUT" | head -1)"
+    fi
+  fi
+fi
+echo ""
+
+echo "=== Summary ==="
+echo "  gRPC (grpc://$TARGET/):  use for dev/test over SSM tunnel"
+echo "  QUIC (lore://$TARGET/):  requires direct UDP connectivity"
+echo "  QUIC+TLS (lores://):     requires UDP + SSL_CERT_FILE bundle"

--- a/modules/unreal/lore/tests/01_vpc.tftest.hcl
+++ b/modules/unreal/lore/tests/01_vpc.tftest.hcl
@@ -1,0 +1,71 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = {
+      name = "us-east-1"
+    }
+  }
+}
+mock_provider "tls" {}
+mock_provider "random" {}
+
+run "creates_vpc_when_vpc_id_is_null" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    vpc_id                = null
+    vpc_cidr              = "10.0.0.0/16"
+    availability_zones    = ["us-east-1a", "us-east-1b"]
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = length(module.vpc) == 1
+    error_message = "VPC module should be created when vpc_id is null"
+  }
+}
+
+run "skips_vpc_when_vpc_id_provided" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    vpc_id                = "vpc-12345678"
+    private_subnet_ids    = ["subnet-aaa", "subnet-bbb"]
+    public_subnet_ids     = ["subnet-ccc", "subnet-ddd"]
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = length(module.vpc) == 0
+    error_message = "VPC module should be skipped when vpc_id is provided"
+  }
+}
+
+run "name_prefix_uses_project_and_environment" {
+  command = plan
+
+  variables {
+    project_prefix        = "mystudio"
+    environment           = "prod"
+    vpc_id                = null
+    vpc_cidr              = "10.0.0.0/16"
+    availability_zones    = ["us-east-1a", "us-east-1b"]
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = local.name_prefix == "mystudio-prod"
+    error_message = "name_prefix should be project_prefix-environment"
+  }
+}

--- a/modules/unreal/lore/tests/02_data.tftest.hcl
+++ b/modules/unreal/lore/tests/02_data.tftest.hcl
@@ -1,0 +1,46 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = { name = "us-east-1" }
+  }
+}
+mock_provider "tls" {}
+mock_provider "random" {}
+
+run "data_module_outputs_use_name_prefix" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    vpc_id                = null
+    vpc_cidr              = "10.0.0.0/16"
+    availability_zones    = ["us-east-1a", "us-east-1b"]
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = module.data.fragments_table_name == "lore-dev-fragments"
+    error_message = "Fragments table name should be lore-dev-fragments"
+  }
+
+  assert {
+    condition     = module.data.fragment_metadata_table_name == "lore-dev-fragment-metadata"
+    error_message = "Fragment metadata table name should be lore-dev-fragment-metadata"
+  }
+
+  assert {
+    condition     = module.data.mutable_store_table_name == "lore-dev-mutable-typed-store"
+    error_message = "Mutable store table name should be lore-dev-mutable-typed-store"
+  }
+
+  assert {
+    condition     = module.data.locks_table_name == "lore-dev-locks"
+    error_message = "Locks table name should be lore-dev-locks"
+  }
+}

--- a/modules/unreal/lore/tests/03_networking.tftest.hcl
+++ b/modules/unreal/lore/tests/03_networking.tftest.hcl
@@ -1,0 +1,29 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = { name = "us-east-1" }
+  }
+}
+mock_provider "tls" {}
+mock_provider "random" {}
+
+run "networking_module_plans_successfully" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    vpc_id                = null
+    vpc_cidr              = "10.0.0.0/16"
+    availability_zones    = ["us-east-1a", "us-east-1b"]
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+  }
+
+  # Plan succeeds = SG, VPC endpoints, and all rules are valid configuration
+  # Detailed port/protocol assertions require Live tests (resource IDs unknown at plan time)
+}

--- a/modules/unreal/lore/tests/05_security.tftest.hcl
+++ b/modules/unreal/lore/tests/05_security.tftest.hcl
@@ -1,0 +1,132 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = { name = "us-east-1" }
+  }
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-east-1a", "us-east-1b"]
+    }
+  }
+}
+mock_provider "tls" {}
+mock_provider "random" {}
+mock_provider "archive" {}
+
+# =============================================================================
+# Default mode: auth_mode=none, ADOT enabled
+# =============================================================================
+
+run "default_mode_plans_successfully" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+  }
+
+  assert {
+    condition     = output.cognito_user_pool_id == null
+    error_message = "Cognito should not be provisioned when auth_mode=none"
+  }
+
+  assert {
+    condition     = output.cognito_client_id == null
+    error_message = "Cognito client should not exist when auth_mode=none"
+  }
+}
+
+# =============================================================================
+# Cognito mode
+# =============================================================================
+
+run "cognito_mode_plans_successfully" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+    auth_mode             = "cognito"
+  }
+}
+
+# =============================================================================
+# External mode — with required endpoints
+# =============================================================================
+
+run "external_mode_plans_successfully" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+    auth_mode             = "external"
+    auth_jwk_endpoint     = "https://example.com/.well-known/jwks.json"
+    auth_jwt_issuer       = "https://example.com"
+  }
+
+  assert {
+    condition     = output.cognito_user_pool_id == null
+    error_message = "Cognito should not be provisioned when auth_mode=external"
+  }
+}
+
+# =============================================================================
+# External mode — missing endpoint fails validation
+# =============================================================================
+
+run "external_mode_requires_jwk_endpoint" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+    auth_mode             = "external"
+    auth_jwt_issuer       = "https://example.com"
+  }
+
+  expect_failures = [var.auth_jwk_endpoint]
+}
+
+run "external_mode_requires_jwt_issuer" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+    auth_mode             = "external"
+    auth_jwk_endpoint     = "https://example.com/.well-known/jwks.json"
+  }
+
+  expect_failures = [var.auth_jwt_issuer]
+}
+
+# =============================================================================
+# ADOT disabled
+# =============================================================================
+
+run "otel_disabled_plans_successfully" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+    enable_otel_sidecar   = false
+  }
+}

--- a/modules/unreal/lore/tests/06_observability.tftest.hcl
+++ b/modules/unreal/lore/tests/06_observability.tftest.hcl
@@ -1,0 +1,49 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = { name = "us-east-1" }
+  }
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-east-1a", "us-east-1b"]
+    }
+  }
+}
+mock_provider "tls" {}
+mock_provider "random" {}
+mock_provider "archive" {}
+
+# =============================================================================
+# X-Ray smoke test enabled (default)
+# =============================================================================
+
+run "xray_smoke_test_enabled_by_default" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "placeholder:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+  }
+}
+
+# =============================================================================
+# X-Ray smoke test disabled
+# =============================================================================
+
+run "xray_smoke_test_disabled_plans_successfully" {
+  command = plan
+
+  variables {
+    project_prefix         = "lore"
+    environment            = "dev"
+    container_image        = "placeholder:latest"
+    allowed_ingress_cidrs  = ["10.0.0.0/8"]
+    enable_xray_smoke_test = false
+  }
+}

--- a/modules/unreal/lore/tests/07_examples.tftest.hcl
+++ b/modules/unreal/lore/tests/07_examples.tftest.hcl
@@ -1,0 +1,56 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = {
+      name = "us-east-1"
+    }
+  }
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-east-1a", "us-east-1b"]
+    }
+  }
+  mock_data "aws_ssm_parameter" {
+    defaults = {
+      value = "ami-12345678"
+    }
+  }
+}
+mock_provider "tls" {}
+mock_provider "random" {}
+mock_provider "archive" {}
+
+# Validates that the root module exposes outputs required by operational
+# tooling (deploy-validate-runbook.md, test-client, scripts).
+#
+# Strategy: assert on module.compute and module.networking outputs that
+# are known at plan time (derived from name_prefix, not AWS API calls).
+# If a sub-module output is removed, the root output breaks, and this
+# test catches it.
+
+run "root_module_exposes_operational_outputs" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "123456789012.dkr.ecr.us-east-1.amazonaws.com/loreserver:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+  }
+
+  # ECS cluster name is derived from name_prefix (known at plan time)
+  assert {
+    condition     = output.ecs_cluster_name == "lore-dev-cluster"
+    error_message = "ecs_cluster_name output must be exposed and match expected value"
+  }
+
+  # VPC is created (module count = 1)
+  assert {
+    condition     = length(module.vpc) == 1
+    error_message = "VPC module must be created for output test"
+  }
+}

--- a/modules/unreal/lore/tests/08_arm64.tftest.hcl
+++ b/modules/unreal/lore/tests/08_arm64.tftest.hcl
@@ -1,0 +1,57 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = { name = "us-west-2" }
+  }
+  mock_data "aws_ssm_parameter" {
+    defaults = {
+      value = "ami-arm64mock"
+    }
+  }
+}
+mock_provider "tls" {}
+mock_provider "random" {}
+
+run "c8gd_arm64_plans_successfully" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    vpc_id                = null
+    vpc_cidr              = "10.0.0.0/16"
+    availability_zones    = ["us-west-2a", "us-west-2b"]
+    container_image       = "123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:arm64"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+    instance_type         = "c8gd.8xlarge"
+  }
+
+  assert {
+    condition     = module.compute.cpu_architecture == "ARM64"
+    error_message = "c8gd instances should use ARM64 architecture"
+  }
+}
+
+run "i4i_x86_plans_successfully" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    vpc_id                = null
+    vpc_cidr              = "10.0.0.0/16"
+    availability_zones    = ["us-west-2a", "us-west-2b"]
+    container_image       = "123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:latest"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+    instance_type         = "i4i.xlarge"
+  }
+
+  assert {
+    condition     = module.compute.cpu_architecture == "X86_64"
+    error_message = "i4i instances should use X86_64 architecture"
+  }
+}

--- a/modules/unreal/lore/tests/09_edge_pods.tftest.hcl
+++ b/modules/unreal/lore/tests/09_edge_pods.tftest.hcl
@@ -1,0 +1,40 @@
+mock_provider "aws" {
+  mock_data "aws_iam_policy_document" {
+    defaults = {
+      json = "{\"Version\":\"2012-10-17\",\"Statement\":[]}"
+    }
+  }
+  mock_data "aws_region" {
+    defaults = { name = "us-west-2" }
+  }
+  mock_data "aws_availability_zones" {
+    defaults = {
+      names = ["us-west-2a", "us-west-2b"]
+    }
+  }
+  mock_data "aws_ssm_parameter" {
+    defaults = {
+      value = "ami-arm64mock"
+    }
+  }
+}
+mock_provider "tls" {}
+mock_provider "random" {}
+mock_provider "archive" {}
+
+run "edge_pods_service_discovery_plans" {
+  command = plan
+
+  variables {
+    project_prefix        = "lore"
+    environment           = "dev"
+    container_image       = "123456789012.dkr.ecr.us-west-2.amazonaws.com/loreserver:arm64"
+    allowed_ingress_cidrs = ["10.0.0.0/8"]
+    instance_type         = "c8gd.8xlarge"
+  }
+
+  assert {
+    condition     = output.write_tier_discovery_dns == "write-tier.lore-dev.internal"
+    error_message = "write_tier_discovery_dns must resolve to Cloud Map DNS name"
+  }
+}

--- a/modules/unreal/lore/variables.tf
+++ b/modules/unreal/lore/variables.tf
@@ -1,0 +1,305 @@
+# =============================================================================
+# Identity
+# =============================================================================
+
+variable "project_prefix" {
+  description = "Prefix for all resource names (e.g., 'lore', 'mystudio-lore'). Max 12 chars to fit AWS resource name limits."
+  type        = string
+  default     = "lore"
+  nullable    = false
+
+  validation {
+    condition     = length(var.project_prefix) >= 2 && length(var.project_prefix) <= 12
+    error_message = "project_prefix must be 2-12 characters (prefix + env + resource must fit AWS name limits)."
+  }
+}
+
+variable "environment" {
+  description = "Environment name — controls resource sizing defaults via locals.tf ternary chains. Only dev/staging/prod are supported because environment-aware defaults depend on these exact values."
+  type        = string
+  nullable    = false
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "Environment must be dev, staging, or prod (module defaults depend on these values)."
+  }
+}
+
+# =============================================================================
+# VPC (Decision 12, 14)
+# =============================================================================
+
+variable "vpc_id" {
+  description = "Existing VPC ID. If null, a new VPC is created."
+  type        = string
+  default     = null
+}
+
+variable "private_subnet_ids" {
+  description = "Existing private subnet IDs. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
+variable "public_subnet_ids" {
+  description = "Existing public subnet IDs. Required when vpc_id is set."
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC (only used when vpc_id is null)"
+  type        = string
+  default     = "10.0.0.0/16"
+}
+
+variable "availability_zones" {
+  description = "List of availability zones (only used when vpc_id is null). If null, uses first 2 AZs in the current region."
+  type        = list(string)
+  default     = null
+}
+
+# =============================================================================
+# Networking
+# =============================================================================
+
+variable "allowed_ingress_cidrs" {
+  description = "CIDR blocks allowed to access Lore server ports. No default — must be explicitly provided."
+  type        = list(string)
+}
+
+# =============================================================================
+# Compute (Decisions 3, 4, 7)
+# =============================================================================
+
+variable "container_image" {
+  description = "Loreserver container image URI (e.g., 123456789012.dkr.ecr.us-east-1.amazonaws.com/loreserver:latest)"
+  type        = string
+}
+
+variable "instance_type" {
+  description = "EC2 instance type for ECS capacity provider"
+  type        = string
+  default     = "i4i.xlarge"
+}
+
+variable "container_memory_reservation" {
+  description = "Soft memory reservation (MiB) for the loreserver container. If null, auto-sizes based on instance_type."
+  type        = number
+  default     = null
+}
+
+variable "cache_max_size_bytes" {
+  description = "NVMe cache maximum size in bytes. 0 = auto-size to 80% of instance store capacity based on instance_type."
+  type        = number
+  default     = 0
+}
+
+variable "ami_id" {
+  description = "AMI ID override. If null, uses latest ECS-optimized AL2023. Pin in production for stability."
+  type        = string
+  default     = null
+}
+
+variable "container_user" {
+  description = "User/group for the container process (e.g., '65534', '1000:1000'). Default 65534 (nobody) for non-root."
+  type        = string
+  default     = "65534"
+}
+
+variable "asg_min_size" {
+  description = "ASG minimum size. Null = environment-aware default (dev:0, staging:0, prod:1)"
+  type        = number
+  default     = null
+}
+
+variable "asg_max_size" {
+  description = "ASG maximum size. Null = environment-aware default (dev:1, staging:1, prod:3)"
+  type        = number
+  default     = null
+}
+
+variable "asg_desired_size" {
+  description = "ASG desired capacity. Null = environment-aware default (dev:0, staging:1, prod:1)"
+  type        = number
+  default     = null
+}
+
+variable "require_instance_store" {
+  description = "Validate that instance_type has NVMe instance store. Set false for dev/test on cheaper instances."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "deployment_minimum_healthy_percent" {
+  description = "Lower limit on running tasks during deployment (% of desired_count). Default 66 allows single-task services to deploy without ENI deadlock on small instances."
+  type        = number
+  default     = 66
+  nullable    = false
+}
+
+variable "deployment_maximum_percent" {
+  description = "Upper limit on running tasks during deployment (% of desired_count)."
+  type        = number
+  default     = 200
+  nullable    = false
+}
+
+# =============================================================================
+# Authentication (Decision 10, ADR-0003)
+# =============================================================================
+
+variable "auth_mode" {
+  description = "Authentication mode: 'none' (open access), 'cognito' (AWS-native M2M), 'external' (bring your own IdP)"
+  type        = string
+  default     = "none"
+
+  validation {
+    condition     = contains(["none", "cognito", "external"], var.auth_mode)
+    error_message = "auth_mode must be 'none', 'cognito', or 'external'."
+  }
+}
+
+variable "auth_jwk_endpoint" {
+  description = "JWK endpoint URL (required when auth_mode = 'external')"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.auth_mode != "external" || var.auth_jwk_endpoint != null
+    error_message = "Set auth_jwk_endpoint when using auth_mode = 'external'."
+  }
+}
+
+variable "auth_jwt_issuer" {
+  description = "JWT issuer string (required when auth_mode = 'external')"
+  type        = string
+  default     = null
+
+  validation {
+    condition     = var.auth_mode != "external" || var.auth_jwt_issuer != null
+    error_message = "Set auth_jwt_issuer when using auth_mode = 'external'."
+  }
+}
+
+variable "auth_jwt_audience" {
+  description = "JWT audience values the server accepts"
+  type        = list(string)
+  default     = []
+}
+
+# =============================================================================
+# TLS (Decision 11)
+# =============================================================================
+
+variable "tls_certificate_secret_arn" {
+  description = "Secrets Manager ARN for server TLS certificate. If null, a self-signed cert is generated."
+  type        = string
+  default     = null
+}
+
+variable "tls_private_key_secret_arn" {
+  description = "Secrets Manager ARN for server TLS private key. If null, generated with self-signed cert."
+  type        = string
+  default     = null
+}
+
+variable "tls_san_dns_names" {
+  description = "Additional DNS SANs for the self-signed TLS certificate"
+  type        = list(string)
+  default     = []
+}
+
+variable "hmac_key_secret_arn" {
+  description = "Secrets Manager ARN for HMAC signing key. If null, a random key is generated."
+  type        = string
+  default     = null
+}
+
+# =============================================================================
+# Observability (Decision 9)
+# =============================================================================
+
+variable "enable_otel_sidecar" {
+  description = "Deploy ADOT sidecar for OpenTelemetry collection (CloudWatch + X-Ray)"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "otel_collector_image" {
+  description = "ADOT collector image URI. Override to use a private ECR mirror. Pin to a specific tag in production."
+  type        = string
+  default     = "public.ecr.aws/aws-observability/aws-otel-collector:latest"
+}
+
+variable "enable_xray_smoke_test" {
+  description = "Deploy X-Ray pipeline smoke test Lambda (validates trace delivery + IAM permissions)"
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+# =============================================================================
+# Storage
+# =============================================================================
+
+variable "intelligent_tiering_archive_days" {
+  description = "Days before fragments move to Archive Access tier. 0 disables Intelligent-Tiering entirely."
+  type        = number
+  default     = 90
+
+  validation {
+    condition     = var.intelligent_tiering_archive_days >= 0
+    error_message = "intelligent_tiering_archive_days must be >= 0."
+  }
+}
+
+variable "intelligent_tiering_deep_archive_days" {
+  description = "Days before fragments move to Deep Archive Access tier. Must be > archive_days when both are enabled."
+  type        = number
+  default     = 180
+
+  validation {
+    condition     = var.intelligent_tiering_deep_archive_days >= 0
+    error_message = "intelligent_tiering_deep_archive_days must be >= 0."
+  }
+
+  validation {
+    condition     = var.intelligent_tiering_deep_archive_days == 0 || var.intelligent_tiering_archive_days == 0 || var.intelligent_tiering_deep_archive_days > var.intelligent_tiering_archive_days
+    error_message = "intelligent_tiering_deep_archive_days must be greater than intelligent_tiering_archive_days when both are enabled."
+  }
+}
+
+# =============================================================================
+# Safety
+# =============================================================================
+
+variable "enable_force_destroy" {
+  description = "Allow S3 buckets to be destroyed even when non-empty. Use only in test environments."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "enable_deletion_protection" {
+  description = "Enable deletion protection on DynamoDB tables. Disable for test environments."
+  type        = bool
+  default     = true
+  nullable    = false
+}
+
+variable "enable_vpc_flow_logs" {
+  description = "Enable VPC flow logs to CloudWatch. Adds IAM role and log group."
+  type        = bool
+  default     = false
+  nullable    = false
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log group retention in days."
+  type        = number
+  default     = 30
+  nullable    = false
+}

--- a/modules/unreal/lore/versions.tf
+++ b/modules/unreal/lore/versions.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.9"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.0"
+    }
+  }
+}


### PR DESCRIPTION
Add Epic's Lore version control system module for deploying large binary asset storage infrastructure on AWS. Includes ECS compute tier, S3/DynamoDB storage, optional Cognito/OIDC auth, and edge pod caching.

Source: terraform-aws-lore v2.0.1

**Issue number:** N/A

## Summary

### Changes

Adds a new module at `modules/unreal/lore/` for deploying Epic's Lore — a version control system purpose-built for large binary game assets. The module includes:

- **Compute tier**: ECS tasks on NVMe-backed EC2 instances (ASG-managed)
- **Storage tier**: S3 bucket + DynamoDB tables for durable fragment storage
- **Auth**: Optional Cognito user pool or external OIDC provider
- **Edge pods**: Optional EC2 cache nodes deployable close to developers
- **Service discovery**: AWS Cloud Map for internal connectivity
- **4 examples**: minimal, default, cognito, external-auth
- **8 test files**: Unit tests with mocked providers

### User experience

**Before**: No Terraform module available in the CGD Toolkit for deploying Lore infrastructure.

**After**: Users can deploy a production-ready Lore VCS backend by referencing `modules/unreal/lore/` with their VPC and subnet configuration. Supports multiple auth modes and optional edge caching for distributed teams.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [ ] Changes have been tested
- [ ] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

No. This is a new module addition with no impact on existing modules.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.