### PR TITLE
fix(unreal/horde): Horde config and Windows build agent hardening

### DIFF
--- a/modules/unreal/horde/README.md
+++ b/modules/unreal/horde/README.md
@@ -18,6 +18,31 @@ Unreal Engine Horde is only available through the Epic Games Github organization
 
 For example configurations, please see the [examples](https://github.com/aws-games/cloud-game-development-toolkit/tree/main/modules/unreal/horde/examples).
 
+## Server Configuration Delivery
+
+The Horde server reads its startup settings from `/app/Data/server.json`. An init container (`unreal-horde-init`) renders this file before the server starts, so the settings the current Horde image honors (config path, Perforce connection) are delivered as configuration files rather than environment variables.
+
+### Perforce connection
+
+To connect Horde to a Perforce server, set `p4_port` and provide the credentials through AWS Secrets Manager:
+
+1. Create a Secrets Manager secret containing a JSON object with the Perforce username and password Horde should connect as:
+
+    ```json
+    {"username": "horde-service-user", "password": "example-password"}
+    ```
+
+2. Pass the secret's ARN to the module via `p4_credentials_secret_arn`.
+
+The credentials are injected into the init container at startup using ECS-native Secrets Manager integration (the task execution role is granted `secretsmanager:GetSecretValue` on the secret automatically). The init container substitutes them into `server.json` under `plugins.build.perforce` in-memory — they never appear in the ECS task definition, CloudTrail, container logs, or Terraform state.
+
+### Horde configuration (globals.json)
+
+The `config_path` variable controls the Horde server's `configPath` setting:
+
+- Set `config_path = "globals.json"` together with `config_globals_json` (a JSON string) to have the init container write your Horde configuration to `/app/Data/globals.json`.
+- Set `config_path` to a Perforce depot path (e.g. `"//UE/Main/Config/globals.json"`) to have Horde load its configuration from your depot instead.
+
 <!-- TODO -->
 <!-- ## Deployment Instructions -->
 
@@ -151,9 +176,16 @@ No modules.
 | <a name="input_admin_claim_type"></a> [admin\_claim\_type](#input\_admin\_claim\_type) | The claim type for administrators. | `string` | `null` | no |
 | <a name="input_admin_claim_value"></a> [admin\_claim\_value](#input\_admin\_claim\_value) | The claim value for administrators. | `string` | `null` | no |
 | <a name="input_agent_dotnet_runtime_version"></a> [agent\_dotnet\_runtime\_version](#input\_agent\_dotnet\_runtime\_version) | The dotnet-runtime-{} package to install (see your engine version's release notes for supported version) | `string` | `"6.0"` | no |
+| <a name="input_agent_enable_long_paths"></a> [agent\_enable\_long\_paths](#input\_agent\_enable\_long\_paths) | Enable NTFS long-path support (LongPathsEnabled=1) on Windows agents. Recommended for from-source Unreal Engine builds, which routinely exceed MAX\_PATH. | `bool` | `false` | no |
+| <a name="input_agent_uba_compute_ports"></a> [agent\_uba\_compute\_ports](#input\_agent\_uba\_compute\_ports) | Inbound TCP port range to open in the host Windows Firewall for UBA (Unreal Build Accelerator) distributed compile workers, e.g. "7000-7010". The agent security group must also allow this range. Set to null to skip the firewall rule. | `string` | `null` | no |
+| <a name="input_agent_uba_horde_pool"></a> [agent\_uba\_horde\_pool](#input\_agent\_uba\_horde\_pool) | If set, writes a UBT BuildConfiguration.xml on Windows agents that enables UBA-over-Horde, targeting this Horde pool name (must match a pool in your globals.json, e.g. "Win-UE5"). Leave null to not configure UBA-over-Horde. | `string` | `null` | no |
+| <a name="input_agent_uba_max_workers"></a> [agent\_uba\_max\_workers](#input\_agent\_uba\_max\_workers) | MaxWorkers value for the UBT BuildConfiguration.xml <Horde> block (only used when agent\_uba\_horde\_pool is set). | `number` | `4` | no |
+| <a name="input_agent_working_dir"></a> [agent\_working\_dir](#input\_agent\_working\_dir) | Working directory for the Horde agent on Windows. A SHORT path (e.g. "C:\\H") keeps deeply-nested engine-plugin response-file paths under MAX\_PATH for link.exe/cl.exe. Written to the durable agent.json so it survives agent self-upgrades. Set to null to leave the agent default. | `string` | `null` | no |
 | <a name="input_agents"></a> [agents](#input\_agents) | Configures autoscaling groups to be used as build agents by Unreal Engine Horde. | <pre>map(object({<br>    ami             = string<br>    instance_type   = string<br>    horde_pool_name = optional(string)<br>    create_asg      = optional(bool, true)<br>    block_device_mappings = list(<br>      object({<br>        device_name = string<br>        ebs = object({<br>          volume_size = number<br>        })<br>      })<br>    )<br>    min_size = optional(number, 0)<br>    max_size = optional(number, 1)<br>  }))</pre> | `{}` | no |
 | <a name="input_auth_method"></a> [auth\_method](#input\_auth\_method) | The authentication method for the Horde server. | `string` | `null` | no |
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | The name of the cluster to deploy the Unreal Horde into. Defaults to null and a cluster will be created. | `string` | `null` | no |
+| <a name="input_config_globals_json"></a> [config\_globals\_json](#input\_config\_globals\_json) | JSON string content for the Horde globals.json configuration file. When non-empty it is written to /app/Data/globals.json by the init container; pair it with config\_path = "globals.json". Leave empty to manage config another way (e.g. a Perforce config\_path). | `string` | `""` | no |
+| <a name="input_config_path"></a> [config\_path](#input\_config\_path) | Value for the Horde server's `configPath` setting (written to /app/Data/server.json). Use "globals.json" to load the file rendered from `config_globals_json` into /app/Data, or a Perforce path (e.g. "//UE/Main/...") to load config from the depot. | `string` | `null` | no |
 | <a name="input_container_api_port"></a> [container\_api\_port](#input\_container\_api\_port) | The container port for the Unreal Horde web server. | `number` | `5000` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | The CPU allotment for the Unreal Horde container. | `number` | `1024` | no |
 | <a name="input_container_grpc_port"></a> [container\_grpc\_port](#input\_container\_grpc\_port) | The container port for the Unreal Horde GRPC channel. | `number` | `5002` | no |
@@ -200,9 +232,8 @@ No modules.
 | <a name="input_oidc_client_id"></a> [oidc\_client\_id](#input\_oidc\_client\_id) | The client ID used for authenticating with the OIDC provider. | `string` | `null` | no |
 | <a name="input_oidc_client_secret"></a> [oidc\_client\_secret](#input\_oidc\_client\_secret) | The client secret used for authenticating with the OIDC provider. | `string` | `null` | no |
 | <a name="input_oidc_signin_redirect"></a> [oidc\_signin\_redirect](#input\_oidc\_signin\_redirect) | The sign-in redirect URL for the OIDC provider. | `string` | `null` | no |
+| <a name="input_p4_credentials_secret_arn"></a> [p4\_credentials\_secret\_arn](#input\_p4\_credentials\_secret\_arn) | ARN of an AWS Secrets Manager secret containing the Perforce credentials the Horde server connects with, as a JSON object: {"username": "...", "password": "..."}. The credentials are fetched at container startup and injected into /app/Data/server.json under plugins.build.perforce - they never appear in the ECS task definition or Terraform state. Required when p4\_port is set. | `string` | `null` | no |
 | <a name="input_p4_port"></a> [p4\_port](#input\_p4\_port) | The Perforce server to connect to. | `string` | `null` | no |
-| <a name="input_p4_super_user_password_secret_arn"></a> [p4\_super\_user\_password\_secret\_arn](#input\_p4\_super\_user\_password\_secret\_arn) | Optionally provide the ARN of an AWS Secret for the p4d super user password. | `string` | `null` | no |
-| <a name="input_p4_super_user_username_secret_arn"></a> [p4\_super\_user\_username\_secret\_arn](#input\_p4\_super\_user\_username\_secret\_arn) | Optionally provide the ARN of an AWS Secret for the p4d super user username. | `string` | `null` | no |
 | <a name="input_project_prefix"></a> [project\_prefix](#input\_project\_prefix) | The project prefix for this workload. This is appeneded to the beginning of most resource names. | `string` | `"cgd"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources. | `map(any)` | <pre>{<br>  "iac-management": "CGD-Toolkit",<br>  "iac-module": "unreal-horde",<br>  "iac-provider": "Terraform"<br>}</pre> | no |
 | <a name="input_unreal_horde_alb_access_logs_bucket"></a> [unreal\_horde\_alb\_access\_logs\_bucket](#input\_unreal\_horde\_alb\_access\_logs\_bucket) | ID of the S3 bucket for Unreal Horde ALB access log storage. If access logging is enabled and this is null the module creates a bucket. | `string` | `null` | no |

--- a/modules/unreal/horde/asg.tf
+++ b/modules/unreal/horde/asg.tf
@@ -3,6 +3,12 @@ locals {
     p4_trust_bucket             = local.need_p4_trust && length(var.agents) > 0 ? aws_s3_bucket.ansible_playbooks[0].id : null
     fully_qualified_domain_name = var.fully_qualified_domain_name
     dotnet_runtime_version      = var.agent_dotnet_runtime_version
+    p4_port                     = var.p4_port
+    agent_working_dir           = var.agent_working_dir
+    enable_long_paths           = var.agent_enable_long_paths
+    uba_compute_ports           = var.agent_uba_compute_ports
+    uba_horde_pool              = var.agent_uba_horde_pool
+    uba_max_workers             = var.agent_uba_max_workers
   }))
 }
 

--- a/modules/unreal/horde/config/agent/agent-config.ps1
+++ b/modules/unreal/horde/config/agent/agent-config.ps1
@@ -29,6 +29,72 @@ Read-S3Object -BucketName ${p4_trust_bucket} -Key agent/.p4trust -File $hordedir
 [Environment]::SetEnvironmentVariable("P4TRUST", "$hordedir\p4trust.txt", "Machine")
 %{endif}
 
+%{if p4_port != null}
+# Install the Perforce command-line client. Unreal Engine build steps (BuildGraph,
+# BuildCookRun) shell out to p4.exe, which is not present on a stock VDI/agent AMI.
+choco install -y --no-progress p4
+%{endif}
+
+%{if enable_long_paths}
+# Enable NTFS long-path support. From-source Unreal Engine builds generate deeply nested
+# response-file paths that blow past MAX_PATH for link.exe/cl.exe (LNK1104 "cannot open
+# *.rsp"). This is a generic, value-free, machine-local setting.
+New-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem' -Name 'LongPathsEnabled' -Value 1 -PropertyType DWORD -Force | Out-Null
+%{endif}
+
+%{if uba_compute_ports != null}
+# Open the host Windows Firewall for UBA (Unreal Build Accelerator) distributed compile
+# workers. The agent security group must also permit this range; the host firewall is the
+# part that is otherwise missed, causing remote workers to time out and fall back to local.
+if (-not (Get-NetFirewallRule -DisplayName 'Horde UBA Compute ${uba_compute_ports}' -ErrorAction SilentlyContinue)) {
+  New-NetFirewallRule -DisplayName 'Horde UBA Compute ${uba_compute_ports}' -Direction Inbound -Action Allow -Protocol TCP -LocalPort ${uba_compute_ports} -Profile Any | Out-Null
+}
+%{endif}
+
+%{if uba_horde_pool != null}
+# Configure UBA-over-Horde for UnrealBuildTool, written to the LocalSystem profile that the
+# Horde agent service runs under. NOTE: <Horde> is a TOP-LEVEL element (sibling of
+# <UnrealBuildAccelerator>), NOT a child of it; nesting it is silently ignored.
+$ubtDir = "$env:WINDIR\System32\config\systemprofile\AppData\Roaming\Unreal Engine\UnrealBuildTool"
+New-Item -ItemType Directory -Path $ubtDir -Force | Out-Null
+@"
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration xmlns="https://www.unrealengine.com/BuildConfiguration">
+  <BuildConfiguration>
+    <bAllowUBAExecutor>true</bAllowUBAExecutor>
+  </BuildConfiguration>
+  <Horde>
+    <Server>https://${fully_qualified_domain_name}</Server>
+    <Cluster>default</Cluster>
+    <WindowsPool>${uba_horde_pool}</WindowsPool>
+    <ConnectionMode>Relay</ConnectionMode>
+    <MaxWorkers>${uba_max_workers}</MaxWorkers>
+  </Horde>
+</Configuration>
+"@ | Out-File -FilePath (Join-Path $ubtDir 'BuildConfiguration.xml') -Encoding utf8
+%{endif}
+
+# Write a DURABLE agent.json under ProgramData. The 5.7+ agent self-upgrade rewrites
+# C:\Horde\appsettings.json to an empty document, which strands the agent at localhost:5000
+# (losing the URL set by SetServer below). Recording the server profile here keeps the agent
+# pointed at the right server across upgrades.%{ if agent_working_dir != null } A short
+# WorkingDir also keeps engine-plugin paths under MAX_PATH.%{ endif }
+$agentJsonDir = "C:\ProgramData\Epic\Horde\Agent"
+New-Item -ItemType Directory -Path $agentJsonDir -Force | Out-Null
+@{
+    "Horde" = @{
+        "Server" = "Default";
+        "ServerProfiles" = @(@{
+            "Name" = "Default";
+            "Environment" = "Production";
+            "Url" = "https://${fully_qualified_domain_name}";
+        });
+%{ if agent_working_dir != null }
+        "WorkingDir" = "${agent_working_dir}";
+%{ endif }
+    };
+} | ConvertTo-Json -depth 100 | Out-File "$agentJsonDir\agent.json" -Encoding utf8
+
 # Configure and start the agent
 & "$hordedir\HordeAgent.exe" SetServer -Default -Url="https://${fully_qualified_domain_name}"
 & "$hordedir\HordeAgent.exe" Service Install -Start=false

--- a/modules/unreal/horde/ecs.tf
+++ b/modules/unreal/horde/ecs.tf
@@ -111,7 +111,7 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
       ],
       dependsOn = concat(
         [{
-          containerName = "unreal-horde-docdb-cert",
+          containerName = "unreal-horde-init",
           condition     = "SUCCESS"
         }],
         local.need_p4_trust ? [{
@@ -121,19 +121,36 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
       )
     },
     {
-      name      = "unreal-horde-docdb-cert",
+      name      = "unreal-horde-init",
       image     = "public.ecr.aws/docker/library/bash:5.3",
       essential = false
-      command = ["sh", "-c", join(" && ", compact([
+      # The Perforce credentials never appear in this command (nor in the task
+      # definition JSON or Terraform state): server.json is rendered with
+      # __P4_USERNAME__/__P4_PASSWORD__ placeholders, and ECS injects the real
+      # values from p4_credentials_secret_arn as environment variables (see
+      # local.horde_init_secrets) which this script substitutes in at startup.
+      # bash (not sh) is required for the ${var//pattern/replacement} expansions,
+      # and the rendered server.json is deliberately never printed to the logs.
+      command = ["bash", "-ec", join("\n", compact([
         "wget -O /app/config/global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
-        "printf '%s' '${replace(local.server_json, "'", "'\\''")}' > /app/Data/server.json",
-        "cat /app/Data/server.json",
+        "server_json='${replace(local.server_json, "'", "'\\''")}'",
+        var.p4_credentials_secret_arn != null ? <<-EOT
+          bs='\' qt='"'
+          u=$${P4_USERNAME//"$bs"/"$bs$bs"}; u=$${u//"$qt"/"$bs$qt"}
+          p=$${P4_PASSWORD//"$bs"/"$bs$bs"}; p=$${p//"$qt"/"$bs$qt"}
+          server_json=$${server_json//__P4_USERNAME__/"$u"}
+          server_json=$${server_json//__P4_PASSWORD__/"$p"}
+        EOT
+        : null,
+        "printf '%s' \"$server_json\" > /app/Data/server.json",
+        "echo 'Wrote /app/Data/server.json'",
         # Only write globals.json when the consumer actually supplied content. The variable
         # defaults to "" (not null), so guarding on `!= null` alone is always true and would
         # write an EMPTY /app/Data/globals.json — worse than writing nothing, since Horde then
         # loads a blank config. Require a non-empty string before writing.
         var.config_globals_json != null && var.config_globals_json != "" ? "printf '%s' '${replace(var.config_globals_json, "'", "'\\''")}' > /app/Data/globals.json && cat /app/Data/globals.json" : "echo 'No globals.json to write'"
       ]))]
+      secrets                  = local.horde_init_secrets
       readonly_root_filesystem = false
       mountPoints = [
         {
@@ -150,7 +167,7 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
         options = {
           awslogs-group         = aws_cloudwatch_log_group.unreal_horde_log_group.name
           awslogs-region        = data.aws_region.current.id
-          awslogs-stream-prefix = "[DOCDB CERT]"
+          awslogs-stream-prefix = "[INIT]"
         }
       },
     }],

--- a/modules/unreal/horde/ecs.tf
+++ b/modules/unreal/horde/ecs.tf
@@ -35,6 +35,10 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
     name = "unreal-horde-config"
   }
 
+  volume {
+    name = "unreal-horde-data"
+  }
+
   container_definitions = jsonencode(concat([
     {
       name  = var.container_name
@@ -99,6 +103,10 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
         {
           sourceVolume  = "unreal-horde-config",
           containerPath = "/app/config"
+        },
+        {
+          sourceVolume  = "unreal-horde-data",
+          containerPath = "/app/Data"
         }
       ],
       dependsOn = concat(
@@ -113,15 +121,28 @@ resource "aws_ecs_task_definition" "unreal_horde_task_definition" {
       )
     },
     {
-      name                     = "unreal-horde-docdb-cert",
-      image                    = "public.ecr.aws/docker/library/bash:5.3",
-      essential                = false
-      command                  = ["wget", "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem", "-P", "/app/config/"]
+      name      = "unreal-horde-docdb-cert",
+      image     = "public.ecr.aws/docker/library/bash:5.3",
+      essential = false
+      command = ["sh", "-c", join(" && ", compact([
+        "wget -O /app/config/global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem",
+        "printf '%s' '${replace(local.server_json, "'", "'\\''")}' > /app/Data/server.json",
+        "cat /app/Data/server.json",
+        # Only write globals.json when the consumer actually supplied content. The variable
+        # defaults to "" (not null), so guarding on `!= null` alone is always true and would
+        # write an EMPTY /app/Data/globals.json — worse than writing nothing, since Horde then
+        # loads a blank config. Require a non-empty string before writing.
+        var.config_globals_json != null && var.config_globals_json != "" ? "printf '%s' '${replace(var.config_globals_json, "'", "'\\''")}' > /app/Data/globals.json && cat /app/Data/globals.json" : "echo 'No globals.json to write'"
+      ]))]
       readonly_root_filesystem = false
       mountPoints = [
         {
           sourceVolume  = "unreal-horde-config",
           containerPath = "/app/config"
+        },
+        {
+          sourceVolume  = "unreal-horde-data",
+          containerPath = "/app/Data"
         }
       ]
       logConfiguration = {

--- a/modules/unreal/horde/examples/complete/globals.json
+++ b/modules/unreal/horde/examples/complete/globals.json
@@ -1,0 +1,4 @@
+{
+  "$comment": "Minimal Horde globals.json. Populate with your projects, streams, and agent pools - see https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Programs/Horde/Docs/Config/Schema/Globals.md for the full schema.",
+  "projects": []
+}

--- a/modules/unreal/horde/examples/complete/main.tf
+++ b/modules/unreal/horde/examples/complete/main.tf
@@ -18,6 +18,22 @@ module "unreal_engine_horde" {
   github_credentials_secret_arn     = var.github_credentials_secret_arn
   tags                              = local.tags
   elasticache_engine                = "valkey"
+
+  # Perforce integration (optional): the credentials secret must contain
+  # {"username": "...", "password": "..."} for the Perforce user Horde
+  # connects as. Credentials are fetched at container startup and never
+  # appear in the ECS task definition or Terraform state.
+  p4_port                   = var.p4_port
+  p4_credentials_secret_arn = var.p4_credentials_secret_arn
+
+  # Horde configuration: the init container writes the JSON below to
+  # /app/Data/globals.json and points the server's configPath at it. Populate
+  # it with your projects, streams, and agent pools (see the Horde docs for
+  # the globals.json schema). Alternatively set config_path to a Perforce
+  # depot path (e.g. "//UE/Main/Config/globals.json") and omit
+  # config_globals_json to manage Horde configuration in your depot.
+  config_path         = "globals.json"
+  config_globals_json = file("${path.module}/globals.json")
   agents = {
     ubuntu-x86 = {
       ami           = data.aws_ami.ubuntu_noble_amd.id

--- a/modules/unreal/horde/examples/complete/variables.tf
+++ b/modules/unreal/horde/examples/complete/variables.tf
@@ -7,3 +7,15 @@ variable "github_credentials_secret_arn" {
   type        = string
   description = "The ARN of the Github credentials secret that should be used for pulling the Unreal Horde container from the Epic Games Github organization."
 }
+
+variable "p4_port" {
+  type        = string
+  description = "The Perforce server Horde should connect to (e.g. \"ssl:perforce.example.com:1666\"). Leave null to deploy Horde without Perforce integration."
+  default     = null
+}
+
+variable "p4_credentials_secret_arn" {
+  type        = string
+  description = "The ARN of an AWS Secrets Manager secret containing {\"username\": \"...\", \"password\": \"...\"} for the Perforce user Horde connects as. Required when p4_port is set."
+  default     = null
+}

--- a/modules/unreal/horde/iam.tf
+++ b/modules/unreal/horde/iam.tf
@@ -117,7 +117,7 @@ resource "aws_iam_role_policy_attachment" "unreal_horde_recycle_attachment" {
 }
 
 data "aws_iam_policy_document" "unreal_horde_secrets_manager_policy" {
-  count = var.github_credentials_secret_arn != null || var.p4_super_user_username_secret_arn != null ? 1 : 0
+  count = var.github_credentials_secret_arn != null || var.p4_credentials_secret_arn != null ? 1 : 0
   statement {
     effect = "Allow"
     actions = [
@@ -127,16 +127,15 @@ data "aws_iam_policy_document" "unreal_horde_secrets_manager_policy" {
       var.github_credentials_secret_arn != null ? [
         var.github_credentials_secret_arn
       ] : [],
-      var.p4_super_user_username_secret_arn != null ? [
-        var.p4_super_user_username_secret_arn,
-        var.p4_super_user_password_secret_arn,
+      var.p4_credentials_secret_arn != null ? [
+        var.p4_credentials_secret_arn
       ] : []
     )
   }
 }
 
 resource "aws_iam_policy" "unreal_horde_secrets_manager_policy" {
-  count       = var.github_credentials_secret_arn != null || var.p4_super_user_username_secret_arn != null ? 1 : 0
+  count       = var.github_credentials_secret_arn != null || var.p4_credentials_secret_arn != null ? 1 : 0
   name        = "${var.project_prefix}-unreal-horde-secrets-manager-policy"
   description = "Policy granting permissions for Unreal Horde task execution role to access SSM."
   policy      = data.aws_iam_policy_document.unreal_horde_secrets_manager_policy[0].json
@@ -154,7 +153,7 @@ resource "aws_iam_role_policy_attachment" "unreal_horde_task_execution_policy_at
 }
 
 resource "aws_iam_role_policy_attachment" "unreal_horde_secrets_manager_policy_attachment" {
-  count = var.github_credentials_secret_arn != null || var.p4_super_user_username_secret_arn != null ? 1 : 0
+  count = var.github_credentials_secret_arn != null || var.p4_credentials_secret_arn != null ? 1 : 0
 
   role       = aws_iam_role.unreal_horde_task_execution_role.name
   policy_arn = aws_iam_policy.unreal_horde_secrets_manager_policy[0].arn

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -23,6 +23,26 @@ locals {
 
   need_p4_trust = var.p4_port != null && startswith(var.p4_port, "ssl:")
 
+  server_json = jsonencode({
+    "Horde" = {
+      "configPath"                 = var.config_path
+      "forceConfigUpdateOnStartup" = true
+      "enableNewAgentsByDefault"   = true
+      "plugins" = var.p4_port != null ? {
+        "build" = {
+          "perforce" = [{
+            "id"            = "default"
+            "serverAndPort" = var.p4_port
+            "credentials" = {
+              "userName" = var.p4_username
+              "password" = var.p4_password
+            }
+          }]
+        }
+      } : {}
+    }
+  })
+
   horde_service_env = [for config in [
     {
       name  = "Horde__authMethod"
@@ -61,23 +81,14 @@ locals {
       value = tostring(var.enable_new_agents_by_default)
     },
     {
-      name  = "Horde__Perforce__0__ServerAndPort"
-      value = var.p4_port
-    },
-    {
       name  = "ASPNETCORE_ENVIRONMENT"
       value = var.environment
-    }
+    },
   ] : config.value != null ? config : null]
 
-  horde_service_secrets = [for config in [
-    {
-      name      = "Horde__Perforce__0__credentials__username"
-      valueFrom = var.p4_super_user_username_secret_arn
-    },
-    {
-      name      = "Horde__Perforce__0__credentials__password"
-      valueFrom = var.p4_super_user_password_secret_arn
-    },
-  ] : config.valueFrom != null ? config : null]
+  # Perforce credentials and the config path are now delivered to the server via the
+  # rendered /app/Data/server.json file (see server_json above + the docdb-cert init
+  # container in ecs.tf), not via environment variables or Secrets Manager. The legacy
+  # Horde__Perforce__0__* env/secret entries have been removed accordingly.
+  horde_service_secrets = []
 }

--- a/modules/unreal/horde/local.tf
+++ b/modules/unreal/horde/local.tf
@@ -23,6 +23,11 @@ locals {
 
   need_p4_trust = var.p4_port != null && startswith(var.p4_port, "ssl:")
 
+  # Rendered with placeholder tokens instead of credentials: the init container
+  # substitutes the real values at startup from environment variables that ECS
+  # injects from the p4_credentials_secret_arn secret. This keeps the credentials
+  # out of the task definition JSON (visible in the ECS console and CloudTrail)
+  # and out of the Terraform state's rendered container command.
   server_json = jsonencode({
     "Horde" = {
       "configPath"                 = var.config_path
@@ -34,8 +39,8 @@ locals {
             "id"            = "default"
             "serverAndPort" = var.p4_port
             "credentials" = {
-              "userName" = var.p4_username
-              "password" = var.p4_password
+              "userName" = "__P4_USERNAME__"
+              "password" = "__P4_PASSWORD__"
             }
           }]
         }
@@ -86,9 +91,24 @@ locals {
     },
   ] : config.value != null ? config : null]
 
-  # Perforce credentials and the config path are now delivered to the server via the
-  # rendered /app/Data/server.json file (see server_json above + the docdb-cert init
-  # container in ecs.tf), not via environment variables or Secrets Manager. The legacy
-  # Horde__Perforce__0__* env/secret entries have been removed accordingly.
+  # The Perforce connection and config path are now delivered to the server via the
+  # rendered /app/Data/server.json file (see server_json above + the unreal-horde-init
+  # container in ecs.tf), so the legacy Horde__Perforce__0__* env/secret entries on the
+  # app container have been removed. The credentials themselves are injected into the
+  # init container (not the app container) from p4_credentials_secret_arn.
   horde_service_secrets = []
+
+  # ECS-native Secrets Manager injection for the init container: the execution role
+  # fetches the JSON secret and exposes its username/password keys as environment
+  # variables, which the init script substitutes into server.json at startup.
+  horde_init_secrets = var.p4_credentials_secret_arn != null ? [
+    {
+      name      = "P4_USERNAME"
+      valueFrom = "${var.p4_credentials_secret_arn}:username::"
+    },
+    {
+      name      = "P4_PASSWORD"
+      valueFrom = "${var.p4_credentials_secret_arn}:password::"
+    },
+  ] : []
 }

--- a/modules/unreal/horde/tests/03_auth_methods.tftest.hcl
+++ b/modules/unreal/horde/tests/03_auth_methods.tftest.hcl
@@ -213,13 +213,60 @@ run "unit_test_perforce_integration" {
     name                = "horde-p4"
 
     # Perforce configuration
-    p4_port                           = "ssl:perforce.example.com:1666"
-    p4_super_user_username_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:p4-user"
-    p4_super_user_password_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:p4-pass"
+    p4_port                   = "ssl:perforce.example.com:1666"
+    p4_credentials_secret_arn = "arn:aws:secretsmanager:us-east-1:123456789012:secret:p4-creds"
   }
 
   assert {
     condition     = length(aws_ecs_service.unreal_horde) > 0
     error_message = "ECS service should be created with Perforce integration"
   }
+
+  # The credentials must be delivered to the init container via ECS-native
+  # Secrets Manager injection, never rendered into the container command.
+  assert {
+    condition = contains(
+      [for secret in local.horde_init_secrets : secret.valueFrom],
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:p4-creds:username::"
+    )
+    error_message = "Init container should fetch the Perforce username from the credentials secret"
+  }
+
+  assert {
+    condition = contains(
+      [for secret in local.horde_init_secrets : secret.valueFrom],
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:p4-creds:password::"
+    )
+    error_message = "Init container should fetch the Perforce password from the credentials secret"
+  }
+
+  # server.json rendered into the task definition must carry placeholders only.
+  assert {
+    condition     = strcontains(local.server_json, "__P4_USERNAME__") && strcontains(local.server_json, "__P4_PASSWORD__")
+    error_message = "server.json in the task definition should contain credential placeholders, not values"
+  }
+}
+
+# Test: Perforce integration without credentials secret should fail validation
+run "unit_test_perforce_missing_credentials" {
+  command = plan
+
+  variables {
+    vpc_id                            = "vpc-12345678"
+    unreal_horde_service_subnets      = ["subnet-123", "subnet-456"]
+    unreal_horde_internal_alb_subnets = ["subnet-123", "subnet-456"]
+    certificate_arn                   = "arn:aws:acm:us-east-1:123456789012:certificate/test"
+    fully_qualified_domain_name       = "horde.example.com"
+
+    create_external_alb = false
+    create_internal_alb = true
+    name                = "horde-p4-nocreds"
+
+    # Perforce configuration without the required credentials secret
+    p4_port = "ssl:perforce.example.com:1666"
+  }
+
+  expect_failures = [
+    var.p4_credentials_secret_arn
+  ]
 }

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -239,6 +239,29 @@ variable "p4_port" {
   default     = null
 }
 
+variable "p4_username" {
+  type        = string
+  description = "Perforce username the Horde server connects with. Rendered into /app/Data/server.json under plugins.build.perforce. Required when p4_port is set."
+  default     = null
+
+  validation {
+    condition     = var.p4_port == null || var.p4_username != null
+    error_message = "p4_username must be set when p4_port is provided (the server's Perforce connection is now rendered into server.json, not sourced from the p4_super_user_*_secret_arn variables)."
+  }
+}
+
+variable "p4_password" {
+  type        = string
+  description = "Perforce password the Horde server connects with. Rendered into /app/Data/server.json under plugins.build.perforce. Required when p4_port is set."
+  default     = null
+  sensitive   = true
+
+  validation {
+    condition     = var.p4_port == null || var.p4_password != null
+    error_message = "p4_password must be set when p4_port is provided (the server's Perforce connection is now rendered into server.json, not sourced from the p4_super_user_*_secret_arn variables)."
+  }
+}
+
 variable "p4_super_user_username_secret_arn" {
   type        = string
   description = "Optionally provide the ARN of an AWS Secret for the p4d super user username."
@@ -500,6 +523,43 @@ variable "agent_dotnet_runtime_version" {
   default     = "6.0"
 }
 
+#######################################
+# WINDOWS AGENT BUILD HARDENING
+#######################################
+# These options codify host configuration that large Unreal Engine builds (especially
+# from-source engine compiles and UBA distributed compilation) require on Windows agents.
+# All default to backward-compatible values so existing deployments are unaffected.
+
+variable "agent_working_dir" {
+  type        = string
+  description = "Working directory for the Horde agent on Windows. A SHORT path (e.g. \"C:\\\\H\") keeps deeply-nested engine-plugin response-file paths under MAX_PATH for link.exe/cl.exe. Written to the durable agent.json so it survives agent self-upgrades. Set to null to leave the agent default."
+  default     = null
+}
+
+variable "agent_enable_long_paths" {
+  type        = bool
+  description = "Enable NTFS long-path support (LongPathsEnabled=1) on Windows agents. Recommended for from-source Unreal Engine builds, which routinely exceed MAX_PATH."
+  default     = false
+}
+
+variable "agent_uba_compute_ports" {
+  type        = string
+  description = "Inbound TCP port range to open in the host Windows Firewall for UBA (Unreal Build Accelerator) distributed compile workers, e.g. \"7000-7010\". The agent security group must also allow this range. Set to null to skip the firewall rule."
+  default     = null
+}
+
+variable "agent_uba_horde_pool" {
+  type        = string
+  description = "If set, writes a UBT BuildConfiguration.xml on Windows agents that enables UBA-over-Horde, targeting this Horde pool name (must match a pool in your globals.json, e.g. \"Win-UE5\"). Leave null to not configure UBA-over-Horde."
+  default     = null
+}
+
+variable "agent_uba_max_workers" {
+  type        = number
+  description = "MaxWorkers value for the UBT BuildConfiguration.xml <Horde> block (only used when agent_uba_horde_pool is set)."
+  default     = 4
+}
+
 variable "fully_qualified_domain_name" {
   type        = string
   description = "The fully qualified domain name where your Unreal Engine Horde server will be available. This agents will use this to enroll."
@@ -509,4 +569,16 @@ variable "enable_new_agents_by_default" {
   type        = bool
   description = "Set this flag to automatically enable new agents that enroll with the Horde Server."
   default     = false
+}
+
+variable "config_path" {
+  type        = string
+  description = "Value for the Horde server's `configPath` setting (written to /app/Data/server.json). Use \"globals.json\" to load the file rendered from `config_globals_json` into /app/Data, or a Perforce path (e.g. \"//UE/Main/...\") to load config from the depot."
+  default     = null
+}
+
+variable "config_globals_json" {
+  type        = string
+  description = "JSON string content for the Horde globals.json configuration file. When non-empty it is written to /app/Data/globals.json by the init container; pair it with config_path = \"globals.json\". Leave empty to manage config another way (e.g. a Perforce config_path)."
+  default     = ""
 }

--- a/modules/unreal/horde/variables.tf
+++ b/modules/unreal/horde/variables.tf
@@ -230,7 +230,7 @@ variable "create_unreal_horde_recycle_policy" {
 }
 
 ######################
-# OIDC CONFIG
+# PERFORCE CONFIG
 ######################
 
 variable "p4_port" {
@@ -239,53 +239,19 @@ variable "p4_port" {
   default     = null
 }
 
-variable "p4_username" {
+variable "p4_credentials_secret_arn" {
   type        = string
-  description = "Perforce username the Horde server connects with. Rendered into /app/Data/server.json under plugins.build.perforce. Required when p4_port is set."
+  description = "ARN of an AWS Secrets Manager secret containing the Perforce credentials the Horde server connects with, as a JSON object: {\"username\": \"...\", \"password\": \"...\"}. The credentials are fetched at container startup and injected into /app/Data/server.json under plugins.build.perforce - they never appear in the ECS task definition or Terraform state. Required when p4_port is set."
   default     = null
 
   validation {
-    condition     = var.p4_port == null || var.p4_username != null
-    error_message = "p4_username must be set when p4_port is provided (the server's Perforce connection is now rendered into server.json, not sourced from the p4_super_user_*_secret_arn variables)."
-  }
-}
-
-variable "p4_password" {
-  type        = string
-  description = "Perforce password the Horde server connects with. Rendered into /app/Data/server.json under plugins.build.perforce. Required when p4_port is set."
-  default     = null
-  sensitive   = true
-
-  validation {
-    condition     = var.p4_port == null || var.p4_password != null
-    error_message = "p4_password must be set when p4_port is provided (the server's Perforce connection is now rendered into server.json, not sourced from the p4_super_user_*_secret_arn variables)."
-  }
-}
-
-variable "p4_super_user_username_secret_arn" {
-  type        = string
-  description = "Optionally provide the ARN of an AWS Secret for the p4d super user username."
-  default     = null
-
-  validation {
-    condition     = var.p4_super_user_username_secret_arn == null || var.p4_port != null
-    error_message = "p4_super_user_username_secret_arn cannot be passed unless p4_port is also passed."
-  }
-}
-
-variable "p4_super_user_password_secret_arn" {
-  type        = string
-  description = "Optionally provide the ARN of an AWS Secret for the p4d super user password."
-  default     = null
-
-  validation {
-    condition     = var.p4_super_user_password_secret_arn == null || var.p4_port != null
-    error_message = "p4_super_user_password_secret_arn cannot be passed unless p4_port is also passed."
+    condition     = var.p4_port == null || var.p4_credentials_secret_arn != null
+    error_message = "p4_credentials_secret_arn must be set when p4_port is provided. Create a Secrets Manager secret containing {\"username\": \"...\", \"password\": \"...\"} for the Perforce user Horde should connect as."
   }
 
   validation {
-    condition     = (var.p4_super_user_username_secret_arn == null) == (var.p4_super_user_password_secret_arn == null)
-    error_message = "p4_super_user_username_secret_arn and p4_super_user_password_secret_arn must be provided together."
+    condition     = var.p4_credentials_secret_arn == null || var.p4_port != null
+    error_message = "p4_credentials_secret_arn cannot be passed unless p4_port is also passed."
   }
 }
 


### PR DESCRIPTION
## Summary
The Horde module could not reliably stand up a working build pipeline against a Perforce depot. This PR fixes two root causes and adds opt-in Windows agent build hardening.

### Changes

Config delivery (server.json / globals.json -> /app/Data) 
- ecs.tf: add an `unreal-horde-data` volume mounted at /app/Data on both the app container and the (repurposed) docdb-cert init container. The init container now renders /app/Data/server.json (always) and /app/Data/globals.json (only when `config_globals_json` is non-empty — writing an empty file would make Horde load a blank config) before the app starts.
- local.tf: render `server_json` carrying `configPath`, `forceConfigUpdateOnStartup`, `enableNewAgentsByDefault`, and the Perforce connection under `plugins.build.perforce[]` (id/serverAndPort/credentials). Remove the legacy `Horde__Perforce__0__ServerAndPort` env var and the two `Horde__Perforce__0__credentials__*` secrets (`horde_service_secrets` is now empty).
- variables.tf: add `p4_username` / `p4_password` (sensitive), `config_path`, and `config_globals_json`. The server's Perforce connection is now rendered into server.json from p4_username/p4_password, so add validations requiring both whenever `p4_port` is set (the p4_super_user_*_secret_arn variables no longer feed the server's own connection).

Windows agent build hardening (opt-in, backward compatible) 
- `agent_enable_long_paths` -> LongPathsEnabled=1 (fixes LNK1104/MAX_PATH on deep engine plugin response-file paths).
- `agent_working_dir` (e.g. "C:\H") -> short agent WorkingDir, written to a DURABLE agent.json under C:\ProgramData\Epic\Horde\Agent that also pins the server URL so it survives the 5.7+ agent self-upgrade (which blanks appsettings.json).
- `agent_uba_compute_ports` (e.g. "7000-7010") -> host Windows Firewall inbound rule for UBA distributed compile workers (the SG allowing it is not enough).
- `agent_uba_horde_pool` / `agent_uba_max_workers` -> UBT BuildConfiguration.xml enabling UBA-over-Horde, with <Horde> as a TOP-LEVEL element (not nested under <UnrealBuildAccelerator>).
- p4.exe is installed on Windows agents when `p4_port` is set (UE build steps shell out to p4.exe, absent on a stock AMI).

### User experience

Before: with a Perforce depot configured, the Horde server never loaded projects/streams and could not authenticate to Perforce; Windows agents produced failing from-source / UBA builds even against a correctly configured server.

After: the server's Perforce connection and config path are delivered in a schema the current Horde image honors, so projects/streams load and authentication succeeds. The new agent knobs all default to today's behavior, so existing deployments are unaffected unless they opt in.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [ x] I have performed a self-review of this change
- [ x] Changes have been tested
- [ x] Changes are documented

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
