### PR TITLE
fix(ci): use BOT_PAT for release publish and fix docs-deploy permissions

### DIFF
--- a/.github/workflows/docs-deploy-version.yml
+++ b/.github/workflows/docs-deploy-version.yml
@@ -25,6 +25,8 @@ on:
 permissions:
   contents: write
   pages: write
+  issues: write
+  pull-requests: write
 
 jobs:
   validate:
@@ -34,6 +36,7 @@ jobs:
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     with:
       scope: "all"
       create_issue: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Publish release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.BOT_PAT }}
         run: |
           DRAFT_ID=$(gh api repos/${{ github.repository }}/releases \
             --jq '.[] | select(.draft == true) | .id' | head -1)


### PR DESCRIPTION
## Summary

Fixes two issues preventing the release pipeline from triggering versioned docs deployment:

1. **release.yml**: Changed the publish step from `GITHUB_TOKEN` to `BOT_PAT`. Events created by `GITHUB_TOKEN` don't trigger other workflows (GitHub's infinite loop prevention). Using the bot's PAT allows the `release: published` event to fire `docs-deploy-version.yml`.

2. **docs-deploy-version.yml**: Added `issues: write` and `pull-requests: write` to the top-level permissions block. The `validate` job calls `docs-validate.yml` which has an internal job requiring these permissions. GitHub rejects workflows at parse time (`startup_failure`) when a reusable workflow call requests permissions not declared at the caller's top level.

## What was tested

Full end-to-end on a fork with a PAT:
- ✅ Tag push triggers release workflow
- ✅ Release workflow publishes draft (using PAT)
- ✅ Publish event triggers `docs-deploy-version.yml`
- ✅ `docs-deploy-version.yml` no longer gets `startup_failure`
- ✅ Docs validation runs correctly (fails on pre-existing lint errors tracked by #945, not this PR)

## Also fixes

- Weekly `docs-health-check.yml` has been getting `startup_failure` for the same permissions reason. This fix resolves it for `docs-deploy-version.yml`; `docs-health-check.yml` already has the correct permissions.