### PR TITLE
chore: reduce dependabot frequency from daily to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,14 @@ updates:
       prefix: "chore"
       include: "scope"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    groups:
+      actions-minor-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+
   - package-ecosystem: "terraform"
     directory: "/"
     commit-message:
@@ -26,18 +33,25 @@ updates:
         patterns:
           - "hashicorp/random"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+
   - package-ecosystem: "docker"
     directory: "/docs"
     commit-message:
       prefix: "chore"
       include: "scope"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+
   - package-ecosystem: "pip"
     directory: "/docs"
     commit-message:
       prefix: "chore"
       include: "scope"
     schedule:
-      interval: "daily"
+      interval: "monthly"
+    groups:
+      docs-dependencies:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Reduces dependabot PR noise by changing all ecosystems from daily to monthly checks and adding grouping.

### Changes
- **Schedule**: Daily → Monthly (all 4 ecosystems)
- **GitHub Actions**: Minor/patch bumps grouped into a single PR (major bumps still get individual PRs for review)
- **Pip (docs)**: All doc dependencies grouped into one PR
- **Terraform**: Already grouped by provider (unchanged)
- **Docker**: Monthly instead of daily (unchanged grouping)

### Impact
Before: ~20+ PRs per week
After: ~4-5 PRs per month (one per ecosystem group, plus individual PRs for major bumps)