### PR TITLE
fix(unreal): relax Lore module AWS provider constraint to >= 5.0

### DIFF
--- a/modules/unreal/lore/examples/cognito/versions.tf
+++ b/modules/unreal/lore/examples/cognito/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.9"
   required_providers {
-    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+    aws = { source = "hashicorp/aws", version = ">= 5.0" }
   }
 }

--- a/modules/unreal/lore/examples/default/versions.tf
+++ b/modules/unreal/lore/examples/default/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/unreal/lore/examples/external-auth/versions.tf
+++ b/modules/unreal/lore/examples/external-auth/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.9"
   required_providers {
-    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+    aws = { source = "hashicorp/aws", version = ">= 5.0" }
   }
 }

--- a/modules/unreal/lore/examples/minimal/versions.tf
+++ b/modules/unreal/lore/examples/minimal/versions.tf
@@ -1,6 +1,6 @@
 terraform {
   required_version = ">= 1.9"
   required_providers {
-    aws = { source = "hashicorp/aws", version = "~> 5.0" }
+    aws = { source = "hashicorp/aws", version = ">= 5.0" }
   }
 }

--- a/modules/unreal/lore/modules/auth/README.md
+++ b/modules/unreal/lore/modules/auth/README.md
@@ -9,14 +9,14 @@ Cognito user pool with M2M client credentials grant for Lore server authenticati
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/unreal/lore/modules/auth/versions.tf
+++ b/modules/unreal/lore/modules/auth/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/modules/unreal/lore/modules/compute/README.md
+++ b/modules/unreal/lore/modules/compute/README.md
@@ -11,7 +11,7 @@ This is an internal sub-module of `terraform-aws-lore`. Do not consume directly 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
 | <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
@@ -20,7 +20,7 @@ This is an internal sub-module of `terraform-aws-lore`. Do not consume directly 
 | Name | Version |
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 

--- a/modules/unreal/lore/modules/compute/versions.tf
+++ b/modules/unreal/lore/modules/compute/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/unreal/lore/modules/edge-pod/README.md
+++ b/modules/unreal/lore/modules/edge-pod/README.md
@@ -37,7 +37,7 @@ module "edge_pod" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.0 |
 | <a name="requirement_tls"></a> [tls](#requirement\_tls) | ~> 4.0 |
 
@@ -45,7 +45,7 @@ module "edge_pod" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | ~> 3.0 |
 | <a name="provider_tls"></a> [tls](#provider\_tls) | ~> 4.0 |
 

--- a/modules/unreal/lore/modules/edge-pod/versions.tf
+++ b/modules/unreal/lore/modules/edge-pod/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
     tls = {
       source  = "hashicorp/tls"

--- a/modules/unreal/lore/modules/storage/README.md
+++ b/modules/unreal/lore/modules/storage/README.md
@@ -10,13 +10,13 @@ This is an internal sub-module of `terraform-aws-lore`. Do not consume directly 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/unreal/lore/modules/storage/versions.tf
+++ b/modules/unreal/lore/modules/storage/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/unreal/lore/modules/vpc/README.md
+++ b/modules/unreal/lore/modules/vpc/README.md
@@ -10,13 +10,13 @@ This is an internal sub-module of `terraform-aws-lore`. Do not consume directly 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0 |
 
 ## Modules
 

--- a/modules/unreal/lore/modules/vpc/versions.tf
+++ b/modules/unreal/lore/modules/vpc/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
   }
 }

--- a/modules/unreal/lore/versions.tf
+++ b/modules/unreal/lore/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = ">= 5.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
## Summary
- Changes AWS provider version constraint from `~> 5.0` to `>= 5.0` across the Lore module, all submodules, and examples
- Allows the module to work with both AWS provider v5 and v6, avoiding version conflicts when composing with other modules in this repo that already require v6

## Test plan
- [x] Verify no remaining `~> 5.0` references in the Lore module tree
- [ ] Confirm `terraform init` succeeds with AWS provider v6