### PR TITLE
feat(virtual-workstations): support layering on VDI AMIs

### DIFF
--- a/assets/packer/virtual-workstations/README.md
+++ b/assets/packer/virtual-workstations/README.md
@@ -181,6 +181,94 @@ module "vdi" {
 }
 ```
 
+## Layering another build on top of these AMIs
+
+These templates produce **final, distributable AMIs**: the last provisioners run
+Sysprep to generalize the image. If you want to build *on top* of one — adding a
+licensed engine install, studio tooling, or a game project in a second Packer build
+that sets `source_ami` to this template's output — set `generalize = false`:
+
+```bash
+packer build -var "generalize=false" windows-server-2025-ue-gamedev.pkr.hcl
+```
+
+Your downstream build is then responsible for generalizing the final image.
+
+Layering needs three things. The template handles the first two for you; the third is
+yours:
+
+| # | Where | What | Who |
+|---|---|---|---|
+| 1 | this build | do not Sysprep | `-var "generalize=false"` |
+| 2 | this build, **last** provisioner | `ec2launch reset` | done by the template when `generalize = false` |
+| 3 | **downstream** build, **first** provisioner | `windows-restart` | **you** |
+
+Without 2 the downstream build hangs forever waiting for a password. Without 3 it is
+worse: the downstream build **appears to succeed** while its provisioners do nothing.
+
+### 1 + 2 — this build
+
+Nothing to write. Passing `generalize = false` swaps the Sysprep tail for an
+`ec2launch reset` provisioner, which must be — and is — last, because an inline reset
+shuts the agent down immediately and anything after it would be silently skipped.
+
+**Why the reset is required.** `setAdminAccount` — the task that generates the
+Administrator password and encrypts it to the launch keypair — has frequency
+*once*. This build's own first boot already ran it and recorded success in
+`C:\ProgramData\Amazon\EC2Launch\state\state.json`, with a marker at `.run-once`.
+Both are captured into the AMI. EC2Launch on a downstream instance reads that state
+and skips the task:
+
+```text
+Warning: Skipping task preReady-setAdminAccount-0
+```
+
+so `ec2:GetPasswordData` returns an empty string forever and Packer hangs at
+`Waiting for auto-generated password` until it times out. Note this state comes from
+the instance simply *booting* — the stock AWS Windows AMI is already sysprepped — so
+skipping Sysprep here does not prevent it, and it is not something this template
+causes. `ec2launch reset` deletes that state, and the downstream instance then
+behaves like a genuine first boot.
+
+**Why `generalize = false` is still needed alongside it.** Sysprep's specialize phase
+re-scrambles the Administrator password (via
+`EC2Launch.exe internal randomize-password`) without encrypting it to a keypair, and
+it removes the WinRM listener the downstream build connects through — undoing the
+reset. This is deliberate on AWS's part: it is documented as a security measure to
+stop an instance being reachable after Sysprep if `setAdminAccount` was not
+configured. It is not something to work around, which is why the reset has to happen
+*instead of* Sysprep rather than after it.
+
+### 3 — the downstream build
+
+```hcl
+build {
+  sources = ["source.amazon-ebs.my-layer"]
+
+  # MUST be first. The intermediate AMI was captured with the EC2Launch agent shut
+  # down by `ec2launch reset`, so this instance has never completed a normal boot
+  # cycle and the provisioner environment is not fully initialized. Without this
+  # reboot, provisioners silently produce no output and can lose their
+  # environment_vars mid-run -- and Packer still reports the build as SUCCESSFUL.
+  provisioner "windows-restart" {
+    restart_timeout = "20m"
+    check_registry  = true
+  }
+
+  # ... your provisioners ...
+}
+```
+
+This one is easy to miss because the failure mode is a *passing* build: Packer reports
+success and publishes an AMI that is missing everything the skipped provisioners were
+supposed to install.
+
+### Handling the intermediate image
+
+An un-generalized image retains the build instance's SID and hostname, so treat it as
+a private intermediate artifact — do not publish or share it, and delete it once the
+downstream AMI is built.
+
 ## Troubleshooting
 
 **"Script not found" errors:**

--- a/assets/packer/virtual-workstations/lightweight/windows-server-2025-lightweight.pkr.hcl
+++ b/assets/packer/virtual-workstations/lightweight/windows-server-2025-lightweight.pkr.hcl
@@ -58,6 +58,52 @@ variable "capacity_reservation_preference" {
   description = "Capacity reservation preference: 'open' (use ODCR if available), 'none' (never use ODCR), or null (no preference specified)"
 }
 
+variable "generalize" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    Run Sysprep to generalize the image. Leave true for a final, distributable AMI.
+
+    Set false when this AMI is an INTERMEDIATE layer that a downstream Packer build
+    will use as its source_ami.
+
+    Sysprep's specialize phase re-scrambles the Administrator password without
+    encrypting it to a launch keypair (so ec2:GetPasswordData returns an empty
+    string forever) and removes the WinRM listener, so a downstream build cannot
+    connect to a generalized image.
+
+    When false, this template skips Sysprep and instead runs `ec2launch reset` as
+    its last provisioner, which is required for a downstream build to be able to log
+    in at all: setAdminAccount has frequency "once", this instance's own boot already
+    recorded it as done, and that state is captured into the image. The downstream
+    build is then responsible for generalizing the final image.
+
+    ONE THING IS STILL YOUR RESPONSIBILITY. Make a `windows-restart` the FIRST
+    provisioner of the DOWNSTREAM build. `ec2launch reset` leaves the agent shut
+    down and that state is captured into the image, so without the reboot the
+    downstream build's provisioners can silently do nothing while Packer still
+    reports SUCCESS. See the README section on layering.
+  EOT
+}
+
+locals {
+  # Guards for the tail provisioners below. Both must stay in sync with the name of
+  # the source block, source.amazon-ebs.lightweight; declared here so a rename needs
+  # one edit rather than four.
+  #
+  # `except` rather than `only` on purpose. Packer takes literal build names in both
+  # and silently ignores a name that matches nothing, so a stale name after a rename
+  # degrades differently depending on which you pick:
+  #   except -> the guarded provisioner runs when it should not. Sysprep runs on an
+  #             intermediate image, and the downstream build then fails to connect.
+  #   only   -> the guarded provisioner never runs at all. generalize = true would
+  #             silently ship an UN-generalized AMI as if it were distributable.
+  # The first is a loud failure on a private intermediate; the second is a silent one
+  # in the default, distributable path. Prefer the loud one.
+  skip_when_layering   = var.generalize ? [] : ["amazon-ebs.lightweight"]
+  skip_unless_layering = var.generalize ? ["amazon-ebs.lightweight"] : []
+}
+
 # Version is controlled by CGD Toolkit maintainers
 # Users should not modify this - it aligns with toolkit releases
 locals {
@@ -164,11 +210,13 @@ build {
     elevated_user     = "Administrator"
     elevated_password = build.Password
     script            = "../shared/sysprep.ps1"
+    except            = local.skip_when_layering
   }
 
   # Clean restart before sysprep
   provisioner "windows-restart" {
     restart_timeout = "5m"
+    except          = local.skip_when_layering
   }
 
   # Run sysprep and shutdown
@@ -180,5 +228,37 @@ build {
       "Start-Process -FilePath \"$${env:ProgramFiles}\\Amazon\\EC2Launch\\ec2launch.exe\" -ArgumentList 'sysprep', '--shutdown' -WindowStyle Hidden -Wait:$false",
       "Start-Sleep -Seconds 5"
     ]
+    except = local.skip_when_layering
+  }
+
+  # The generalize = false counterpart of the block above: reset EC2Launch v2's agent
+  # state so an instance launched from this INTERMEDIATE image treats itself as a
+  # first boot and re-runs once-per-instance tasks -- above all setAdminAccount, which
+  # generates the Administrator password and encrypts it to the launch keypair.
+  #
+  # Without this a downstream build cannot connect at all: this instance's own boot
+  # already ran setAdminAccount and recorded it in state.json (with a marker at
+  # .run-once), both of which are captured into the AMI, so EC2Launch downstream logs
+  # "Warning: Skipping task preReady-setAdminAccount-0" and ec2:GetPasswordData
+  # returns an empty string forever.
+  #
+  # MUST be last: an inline reset "runs immediately and resets the agent. The current
+  # task finishes, then the agent shuts down without running any further tasks", so
+  # anything after it would be silently skipped. -c/--clean is deliberately omitted:
+  # it would also delete the instance logs that make a failed build debuggable.
+  provisioner "powershell" {
+    elevated_user     = "Administrator"
+    elevated_password = build.Password
+    inline = [
+      "$launch = Join-Path $env:ProgramFiles 'Amazon\\EC2Launch\\ec2launch.exe'",
+      "if (-not (Test-Path $launch)) { Write-Error \"ec2launch.exe not found at $launch\"; exit 1 }",
+      "Write-Host 'Resetting EC2Launch v2 agent state so the next boot re-runs once-only tasks...'",
+      "& $launch reset",
+      "$state = 'C:\\ProgramData\\Amazon\\EC2Launch\\state'",
+      "if (Test-Path (Join-Path $state '.run-once')) { Write-Error 'ec2launch reset left .run-once in place; a downstream build would skip setAdminAccount'; exit 1 }",
+      "if (Test-Path (Join-Path $state 'state.json')) { Write-Error 'ec2launch reset left state.json in place; a downstream build would skip setAdminAccount'; exit 1 }",
+      "Write-Host 'EC2Launch state reset: .run-once and state.json are gone.'"
+    ]
+    except = local.skip_unless_layering
   }
 }

--- a/assets/packer/virtual-workstations/ue-gamedev/unreal_development_stack.ps1
+++ b/assets/packer/virtual-workstations/ue-gamedev/unreal_development_stack.ps1
@@ -9,15 +9,45 @@ Write-Host "Installing Unreal Engine development stack..."
 # Windows installers update system PATH but current session still has old PATH from when it started
 # Without this refresh, 'choco' command fails and Visual Studio never gets installed
 $env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
-Write-Host "Refreshed PATH - Chocolatey now available in current PowerShell session"
 
-# Verify Chocolatey is available
-try {
-    $chocoVersion = choco --version
-    Write-Host "Chocolatey found: $chocoVersion"
-} catch {
-    Write-Host "Chocolatey not found in PATH - this is required for Unreal development stack" -ForegroundColor Red
+# Resolve choco.exe by absolute path rather than relying on PATH alone. The machine
+# PATH written by the Chocolatey installer in the previous provisioner's session is
+# not always visible to this one yet, which made this check fail intermittently --
+# unchanged builds would resolve Chocolatey on one run and report
+# "Chocolatey dependency not met" on the next.
+$chocoInstall = if ($env:ChocolateyInstall) { $env:ChocolateyInstall } else { Join-Path $env:ProgramData 'chocolatey' }
+$chocoExe = Join-Path $chocoInstall 'bin\choco.exe'
+
+# Give the installer's PATH/filesystem changes a moment to land before giving up.
+$chocoVersion = $null
+foreach ($delay in 0, 5, 10, 20) {
+    if ($delay -gt 0) {
+        Write-Host "Chocolatey not resolvable yet; waiting ${delay}s..."
+        Start-Sleep -Seconds $delay
+    }
+    if (Test-Path $chocoExe) {
+        $chocoVersion = & $chocoExe --version
+        break
+    }
+    # Fall back to PATH lookup in case Chocolatey lives somewhere non-standard.
+    $onPath = Get-Command choco -ErrorAction SilentlyContinue
+    if ($onPath) {
+        $chocoExe = $onPath.Source
+        $chocoVersion = & $chocoExe --version
+        break
+    }
+}
+
+if (-not $chocoVersion) {
+    Write-Host "Chocolatey not found at $chocoExe or on PATH - required for the Unreal development stack" -ForegroundColor Red
     throw "Chocolatey dependency not met"
+}
+Write-Host "Chocolatey found: $chocoVersion (at $chocoExe)"
+
+# Make sure the rest of this script's `choco` calls resolve, even if PATH is stale.
+$chocoBin = Split-Path $chocoExe -Parent
+if ($env:Path -notlike "*$chocoBin*") {
+    $env:Path = "$chocoBin;$env:Path"
 }
 
 try {

--- a/assets/packer/virtual-workstations/ue-gamedev/windows-server-2025-ue-gamedev.pkr.hcl
+++ b/assets/packer/virtual-workstations/ue-gamedev/windows-server-2025-ue-gamedev.pkr.hcl
@@ -58,6 +58,53 @@ variable "capacity_reservation_preference" {
   description = "Capacity reservation preference: 'open' (use ODCR if available), 'none' (never use ODCR), or null (no preference specified)"
 }
 
+variable "generalize" {
+  type        = bool
+  default     = true
+  description = <<-EOT
+    Run Sysprep to generalize the image. Leave true for a final, distributable AMI.
+
+    Set false when this AMI is an INTERMEDIATE layer that a downstream Packer build
+    will use as its source_ami -- for example to add a licensed engine install,
+    studio tooling, or a game project on top of this workstation.
+
+    Sysprep's specialize phase re-scrambles the Administrator password without
+    encrypting it to a launch keypair (so ec2:GetPasswordData returns an empty
+    string forever) and removes the WinRM listener, so a downstream build cannot
+    connect to a generalized image.
+
+    When false, this template skips Sysprep and instead runs `ec2launch reset` as
+    its last provisioner, which is required for a downstream build to be able to log
+    in at all: setAdminAccount has frequency "once", this instance's own boot already
+    recorded it as done, and that state is captured into the image. The downstream
+    build is then responsible for generalizing the final image.
+
+    ONE THING IS STILL YOUR RESPONSIBILITY. Make a `windows-restart` the FIRST
+    provisioner of the DOWNSTREAM build. `ec2launch reset` leaves the agent shut
+    down and that state is captured into the image, so without the reboot the
+    downstream build's provisioners can silently do nothing while Packer still
+    reports SUCCESS. See the README section on layering.
+  EOT
+}
+
+locals {
+  # Guards for the tail provisioners below. Both must stay in sync with the name of
+  # the source block, source.amazon-ebs.ue-gamedev; declared here so a rename needs
+  # one edit rather than four.
+  #
+  # `except` rather than `only` on purpose. Packer takes literal build names in both
+  # and silently ignores a name that matches nothing, so a stale name after a rename
+  # degrades differently depending on which you pick:
+  #   except -> the guarded provisioner runs when it should not. Sysprep runs on an
+  #             intermediate image, and the downstream build then fails to connect.
+  #   only   -> the guarded provisioner never runs at all. generalize = true would
+  #             silently ship an UN-generalized AMI as if it were distributable.
+  # The first is a loud failure on a private intermediate; the second is a silent one
+  # in the default, distributable path. Prefer the loud one.
+  skip_when_layering   = var.generalize ? [] : ["amazon-ebs.ue-gamedev"]
+  skip_unless_layering = var.generalize ? ["amazon-ebs.ue-gamedev"] : []
+}
+
 # Version is controlled by CGD Toolkit maintainers
 # Users should not modify this - it aligns with toolkit releases
 locals {
@@ -166,21 +213,77 @@ build {
     script            = "./unreal_development_stack.ps1"
   }
 
-  # Configure EC2Launch v2 for VDI deployment
+  # Configure EC2Launch v2 for VDI deployment.
+  # Skipped when generalize = false, because this is part of finalizing an image for
+  # distribution and the downstream build owns the image it ships -- it should apply
+  # this config (../shared/sysprep.ps1) itself, alongside its own Sysprep. Leaving it
+  # here would not break a downstream build; it is grouped with the generalize tail
+  # so that generalize = false yields a plain, unfinalized intermediate.
   provisioner "powershell" {
     elevated_user     = "Administrator"
     elevated_password = build.Password
     script            = "../shared/sysprep.ps1"
+    except            = local.skip_when_layering
   }
 
+  # Clean restart before Sysprep, as the lightweight template already does (this one
+  # previously had no restart, with a comment asserting none was needed). This
+  # template installs Visual Studio 2022 and the Epic Games Launcher, which leave
+  # pending-reboot and pending-file-rename state behind; Sysprep is more reliable
+  # against a machine that has completed those. 15m rather than lightweight's 5m
+  # because the first boot after a Visual Studio install is slow.
+  provisioner "windows-restart" {
+    restart_timeout = "15m"
+    except          = local.skip_when_layering
+  }
 
-  # Run sysprep and shutdown - no restart needed
+  # Generalize and shut down, via the EC2Launch v2 wrapper rather than sysprep.exe
+  # directly. Per the EC2Launch v2 task reference the `sysprep` task "Resets the
+  # service state, updates unattend.xml, disables RDP, and runs Sysprep", so the
+  # wrapper keeps the agent's own state consistent with the image it produces.
+  # This also matches the lightweight template, and replaces a call against
+  # C:\ProgramData\Amazon\EC2Launch\sysprep2008.xml -- an EC2Config v1 filename
+  # (which lived under C:\Program Files\Amazon\Ec2ConfigService\) under the
+  # EC2Launch v2 directory, matching neither documented path.
   provisioner "powershell" {
     elevated_user     = "Administrator"
     elevated_password = build.Password
     inline = [
       "Write-Host 'Starting sysprep for UE GameDev VDI AMI...'",
-      "C:\\Windows\\System32\\Sysprep\\sysprep.exe /generalize /oobe /shutdown /unattend:C:\\ProgramData\\Amazon\\EC2Launch\\sysprep2008.xml"
+      "Start-Process -FilePath \"$${env:ProgramFiles}\\Amazon\\EC2Launch\\ec2launch.exe\" -ArgumentList 'sysprep', '--shutdown' -WindowStyle Hidden -Wait:$false",
+      "Start-Sleep -Seconds 5"
     ]
+    except = local.skip_when_layering
+  }
+
+  # The generalize = false counterpart of the block above: reset EC2Launch v2's agent
+  # state so an instance launched from this INTERMEDIATE image treats itself as a
+  # first boot and re-runs once-per-instance tasks -- above all setAdminAccount, which
+  # generates the Administrator password and encrypts it to the launch keypair.
+  #
+  # Without this a downstream build cannot connect at all: this instance's own boot
+  # already ran setAdminAccount and recorded it in state.json (with a marker at
+  # .run-once), both of which are captured into the AMI, so EC2Launch downstream logs
+  # "Warning: Skipping task preReady-setAdminAccount-0" and ec2:GetPasswordData
+  # returns an empty string forever.
+  #
+  # MUST be last: an inline reset "runs immediately and resets the agent. The current
+  # task finishes, then the agent shuts down without running any further tasks", so
+  # anything after it would be silently skipped. -c/--clean is deliberately omitted:
+  # it would also delete the instance logs that make a failed build debuggable.
+  provisioner "powershell" {
+    elevated_user     = "Administrator"
+    elevated_password = build.Password
+    inline = [
+      "$launch = Join-Path $env:ProgramFiles 'Amazon\\EC2Launch\\ec2launch.exe'",
+      "if (-not (Test-Path $launch)) { Write-Error \"ec2launch.exe not found at $launch\"; exit 1 }",
+      "Write-Host 'Resetting EC2Launch v2 agent state so the next boot re-runs once-only tasks...'",
+      "& $launch reset",
+      "$state = 'C:\\ProgramData\\Amazon\\EC2Launch\\state'",
+      "if (Test-Path (Join-Path $state '.run-once')) { Write-Error 'ec2launch reset left .run-once in place; a downstream build would skip setAdminAccount'; exit 1 }",
+      "if (Test-Path (Join-Path $state 'state.json')) { Write-Error 'ec2launch reset left state.json in place; a downstream build would skip setAdminAccount'; exit 1 }",
+      "Write-Host 'EC2Launch state reset: .run-once and state.json are gone.'"
+    ]
+    except = local.skip_unless_layering
   }
 }


### PR DESCRIPTION
## Summary

Both Windows virtual-workstation templates end by running Sysprep, so their output is a
final AMI and nothing else. A second Packer build that sets `source_ami` to one of them
cannot authenticate — `ec2:GetPasswordData` returns an empty string and the build hangs at
`Waiting for auto-generated password`. Layering today requires patching the template at
build time.

This adds a `generalize` variable so the templates can also produce an intermediate layer,
and fixes three pre-existing defects found along the way.

### Changes

1. **`generalize` variable** (default `true`) on both templates. When `false`, the Sysprep
   tail is skipped and an `ec2launch reset` runs last instead. Two causes had to be handled
   together: EC2Launch v2's `setAdminAccount` is frequency-`once` and its completed state is
   captured into the AMI, so a downstream instance skips password generation; and Sysprep
   would undo the reset by re-randomizing the password without encrypting it to a keypair.
   Full explanation, including the caller's one remaining obligation, is in the README
   section this PR adds.
2. **`ec2launch.exe sysprep`** instead of raw `sysprep.exe` in `ue-gamedev`, which passed an
   EC2Config v1 `unattend` filename under the EC2Launch v2 directory. `lightweight` already
   uses the wrapper.
3. **Pre-Sysprep `windows-restart`** in `ue-gamedev`, matching `lightweight`. Visual Studio
   and the Epic Games Launcher leave pending-reboot state behind.
4. **Chocolatey resolved by absolute path** in `unreal_development_stack.ps1`, with retries.
   Fixes an intermittent `Chocolatey dependency not met` failure caused by the machine PATH
   not yet being visible to the next provisioner's session.

### User experience

Before: patch the template at build time — parse the `.pkr.hcl`, delete every Sysprep
provisioner block, append a reset. Breaks on any upstream reformat or reorder.

After:

```bash
packer build -var "generalize=false" windows-server-2025-ue-gamedev.pkr.hcl
```

Unchanged for existing users — `generalize` defaults to `true`, so the default path produces
the same AMI as before.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

`packer validate` passes on both templates with `generalize` true and false (4/4).

<details>
<summary>Is this a breaking change?</summary>

No. `generalize` defaults to `true`, preserving current behaviour. Item 2 is the only change
to the default path and targets the same outcome via the documented EC2Launch v2 wrapper.

`generalize = false` is opt-in and produces an image that is deliberately not distributable —
it retains the build instance's SID and hostname, and should be deleted once the downstream
AMI is built.

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute
this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might
not be successful.