### PR TITLE
fix(lore/edge-pod): strip deprecation mark from region before templat…

### DIFF
--- a/modules/unreal/lore/modules/edge-pod/main.tf
+++ b/modules/unreal/lore/modules/edge-pod/main.tf
@@ -7,6 +7,7 @@ data "aws_ssm_parameter" "al2023_ami" {
 locals {
   instance_family = split(".", var.instance_type)[0]
   is_arm64        = contains(["c8gd", "c8g", "c7gd", "c7g", "c7gn", "m7g", "m7gd", "m8g", "r7g", "r7gd", "r8g", "t4g", "im4gn", "is4gen", "x2gd", "hpc7g"], local.instance_family)
+  ecr_region      = join("", [data.aws_region.current.name]) # strip deprecation mark to avoid templatefile() inconsistency error
   ecr_registry    = split("/", var.container_image)[0]
   hmac_key        = var.hmac_key != null ? var.hmac_key : random_id.hmac[0].hex
 }
@@ -186,7 +187,7 @@ resource "aws_instance" "edge" {
   vpc_security_group_ids = [aws_security_group.edge.id]
 
   user_data_base64 = base64encode(templatefile("${path.module}/userdata.sh.tpl", {
-    ecr_region      = data.aws_region.current.name
+    ecr_region      = local.ecr_region
     ecr_registry    = local.ecr_registry
     ca_cert_pem     = var.ca_certificate_pem
     container_image = var.container_image

--- a/modules/unreal/lore/modules/edge-pod/main.tf
+++ b/modules/unreal/lore/modules/edge-pod/main.tf
@@ -7,7 +7,7 @@ data "aws_ssm_parameter" "al2023_ami" {
 locals {
   instance_family = split(".", var.instance_type)[0]
   is_arm64        = contains(["c8gd", "c8g", "c7gd", "c7g", "c7gn", "m7g", "m7gd", "m8g", "r7g", "r7gd", "r8g", "t4g", "im4gn", "is4gen", "x2gd", "hpc7g"], local.instance_family)
-  ecr_region      = join("", [data.aws_region.current.name]) # strip deprecation mark to avoid templatefile() inconsistency error
+  ecr_region      = data.aws_region.current.region
   ecr_registry    = split("/", var.container_image)[0]
   hmac_key        = var.hmac_key != null ? var.hmac_key : random_id.hmac[0].hex
 }

--- a/modules/unreal/lore/modules/edge-pod/versions.tf
+++ b/modules/unreal/lore/modules/edge-pod/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.0"
+      version = ">= 6.0"
     }
     tls = {
       source  = "hashicorp/tls"


### PR DESCRIPTION
Fixes #971

**Issue number:971**

## Summary

AWS provider v5.x+ attaches a deprecation mark to data.aws_region.current.name. When this marked value is passed into templatefile(), Terraform's consistency checker sees the marks as making the 'was' and 'now' values differ, causing:

  Error: Error in function call
  Call to function "templatefile" failed: function returned an inconsistent result

Fix: use join("", [...]) to produce an unmarked copy of the region string before passing it into templatefile().

### User experience

> Please share what the user experience looks like before and after this change

before: Lore dont work

after: Lore work

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

- [x] I have performed a self-review of this change
- [x] Changes have been tested
- [x] Changes are documented

<details>
<summary>Is this a breaking change?</summary>

</details>

## Acknowledgment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

**Disclaimer**: We value your time and bandwidth. As such, any pull requests created might not be successful.
