### PR TITLE
fix(horde): guard i386/multiarch tasks to Ubuntu for AL2023 agents

### DIFF
--- a/modules/unreal/horde/config/agent/horde-agent.ansible.yml
+++ b/modules/unreal/horde/config/agent/horde-agent.ansible.yml
@@ -26,15 +26,16 @@
       register: result_i386_check
       changed_when: result_i386_check.rc == 1
       failed_when: result_i386_check.rc > 1
+      when: ansible_distribution == "Ubuntu"
     - name: Enable Multiarch
       ansible.builtin.command:
         cmd: dpkg --add-architecture i386
-      when: result_i386_check.rc == 1
+      when: ansible_distribution == "Ubuntu" and result_i386_check.rc == 1
       changed_when: result_i386_check.rc == 1
     - name: Update Cache
       ansible.builtin.apt:
         update_cache: true
-      when: result_i386_check.rc == 1
+      when: ansible_distribution == "Ubuntu" and result_i386_check.rc == 1
     - name: Install Wine on Ubuntu machines
       ansible.builtin.package:
         name: "{{ item }}"


### PR DESCRIPTION
## Summary
The Linux Horde agent Ansible playbook (`modules/unreal/horde/config/agent/horde-agent.ansible.yml`) runs dpkg-based i386/multiarch/apt tasks that are Debian/Ubuntu-only. On Amazon Linux 2023 (and any non-Debian distro), `dpkg --add-architecture i386` fails with `dpkg: No such file or directory`, aborting the whole play **before** the Download/Configure/CreateService/EnableService tasks — so the agent is never installed or enrolled. The sibling Wine/DotNet-backport tasks already carry a `when: ansible_distribution == "Ubuntu"` guard; the i386/multiarch/apt tasks were missing it.

## Change
- Add `when: ansible_distribution == "Ubuntu"` to `Check if i386 enabled`.
- Combine to `ansible_distribution == "Ubuntu" and result_i386_check.rc == 1` on `Enable Multiarch` and `Update Cache` (the register short-circuits safely on non-Ubuntu).

+3/-2, one file.

## Testing / validation
Validated live on an Amazon Linux 2023 Horde sync agent (SSM `AWS-ApplyAnsiblePlaybooks`).
- **Before:** play FAILED at `Enable Multiarch` (dpkg missing).
- **After:** `PLAY RECAP ok=13 changed=6 skipped=5 failed=0` — the 5 Ubuntu/dpkg tasks correctly SKIPPED; play reached Download/Configure/CreateService/EnableService; `horde-agent.service` active (running); agent connected to the Horde server and pending approval.
- YAML syntax validated (`yaml.safe_load` OK).

## Blast radius
Ubuntu agents unaffected (guard matches prior behavior when distro==Ubuntu); only changes behavior on non-Ubuntu (now correctly skips Debian-only steps). No API/interface change.