### PR TITLE
fix(unreal-horde): start Windows Horde agent in-band (#994)

### DIFF
--- a/modules/unreal/horde/config/agent/agent-config.ps1
+++ b/modules/unreal/horde/config/agent/agent-config.ps1
@@ -97,8 +97,15 @@ New-Item -ItemType Directory -Path $agentJsonDir -Force | Out-Null
 
 # Configure and start the agent
 & "$hordedir\HordeAgent.exe" SetServer -Default -Url="https://${fully_qualified_domain_name}"
-& "$hordedir\HordeAgent.exe" Service Install -Start=false
+& "$hordedir\HordeAgent.exe" Service Install -Start=true
 
-# Schedule a reboot in 5 minutes
+# Belt-and-suspenders: ensure the service is running now, independent of any
+# future reboot. -Start=true above should have started it, but if the service
+# was registered as Automatic and deferred, this catches it.
+Start-Service HordeAgent -ErrorAction SilentlyContinue
+
+# Schedule a reboot in 5 minutes — still needed for Rename-Computer and
+# LongPathsEnabled to take full effect. The agent is already running and
+# enrolling; it will re-register cleanly after the reboot.
 shutdown /r /d p:4:2 /t $(60*5)
 </powershell>


### PR DESCRIPTION
## Summary

Fixes the Windows Horde agent bootstrap so the agent starts and enrolls
**in-band**, without depending on the deferred reboot.

Previously `modules/unreal/horde/config/agent/agent-config.ps1` ran:

```
HordeAgent.exe Service Install -Start=false
```

and relied on a scheduled reboot to start the service. If that reboot was
aborted or delayed, the agent never started and the instance never enrolled
with the Horde server.

### Changes (`modules/unreal/horde/config/agent/agent-config.ps1`)
- `Service Install -Start=false` → `-Start=true` so the agent starts and
  enrolls immediately.
- Add `Start-Service HordeAgent -ErrorAction SilentlyContinue` as a
  belt-and-suspenders guard.
- Retain the scheduled reboot — still required for `Rename-Computer` and
  `LongPathsEnabled` to take full effect. The agent is already running and
  enrolling and re-registers cleanly after the reboot.

## Closes
- Closes #994 (Windows agent never starts if the deferred reboot is aborted)

> Note: The all-Windows fleet Linux-only SSM association gate
> (`local.linux_agent_count`) and its unit test in
> `tests/05_agents_platform.tftest.hcl` for #985 are **already merged on
> main** (commit `d4e38507`), so this PR carries only the #994 agent-start
> fix.

## Testing
- `terraform init -backend=false` — success
- `terraform fmt -check -recursive` — pass
- `terraform validate` — valid (only pre-existing `aws_region.id` deprecation warnings)
- `terraform test` (mocked providers, no AWS) — **15 passed, 0 failed**,
  including both platform-gate tests in `tests/05_agents_platform.tftest.hcl`

## Live validation
Validated on a live deployment: the Windows agent enrolled in-band (before
the reboot), and an all-Windows agent fleet applied cleanly with no SSM
`CreateAssociation` error.